### PR TITLE
More convenient HttpBody

### DIFF
--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -1,4 +1,4 @@
 import { setupEnvironment } from "../src/core/env";
-import { TextDecoder } from "util";
+import { TextDecoder, TextEncoder } from "util";
 
-setupEnvironment(TextDecoder as any);
+setupEnvironment(TextDecoder as any, TextEncoder as any);

--- a/src/core/__tests__/HttpRequestImpl.spec.ts
+++ b/src/core/__tests__/HttpRequestImpl.spec.ts
@@ -1,9 +1,9 @@
 import { HttpRequestImpl } from "../HttpRequestImpl";
-import { StringBody } from "../http-body/string-body";
+import { stringBody } from "../http-body/helpers";
 
 describe("HttpRequestImpl", () => {
   it("should add headers", () => {
-    const body = new StringBody("{param: 1}");
+    const body = stringBody("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -24,7 +24,7 @@ describe("HttpRequestImpl", () => {
   });
 
   it("should remove headers", () => {
-    const body = new StringBody("{param: 1}");
+    const body = stringBody("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -39,7 +39,7 @@ describe("HttpRequestImpl", () => {
   });
 
   it("should replace headers", () => {
-    const body = new StringBody("{param: 1}");
+    const body = stringBody("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -63,20 +63,20 @@ describe("HttpRequestImpl", () => {
 
   it("should return query by queryName", () => {
     const url = "http://localhost?q=1&q=2&q=3";
-    const request = new HttpRequestImpl(url, new StringBody(""), "GET", {});
+    const request = new HttpRequestImpl(url, stringBody(""), "GET", {});
     expect(request.query("q")).toEqual(["1", "2", "3"]);
   });
 
   it("should add query", () => {
     const url = "http://localhost?q=1";
-    const request = new HttpRequestImpl(url, new StringBody(""), "GET", {});
+    const request = new HttpRequestImpl(url, stringBody(""), "GET", {});
     expect(request.addQuery("q2", "1").query("q2")).toEqual("1");
     expect(request.addQuery("q2", ["1", "2"]).query("q2")).toEqual(["1", "2"]);
   });
 
   it("should replace query", () => {
     const url = "http://localhost?q=1";
-    const request = new HttpRequestImpl(url, new StringBody(""), "GET", {});
+    const request = new HttpRequestImpl(url, stringBody(""), "GET", {});
     expect(request.replaceQuery("q", ["1", "2"]).query("q")).toEqual([
       "1",
       "2"
@@ -89,7 +89,7 @@ describe("HttpRequestImpl", () => {
 
   it("should remove query", () => {
     const url = "http://localhost?q=1&q2=2";
-    const request = new HttpRequestImpl(url, new StringBody(""), "GET", {});
+    const request = new HttpRequestImpl(url, stringBody(""), "GET", {});
     expect(request.removeQuery("q2").query("q2")).toEqual(undefined);
   });
 });

--- a/src/core/__tests__/HttpRequestImpl.spec.ts
+++ b/src/core/__tests__/HttpRequestImpl.spec.ts
@@ -1,9 +1,9 @@
 import { HttpRequestImpl } from "../HttpRequestImpl";
-import { BufferedBody } from "../../node";
+import { StringBody } from "../http-body/string-body";
 
 describe("HttpRequestImpl", () => {
   it("should add headers", () => {
-    const body = BufferedBody.fromString("{param: 1}");
+    const body = new StringBody("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -24,7 +24,7 @@ describe("HttpRequestImpl", () => {
   });
 
   it("should remove headers", () => {
-    const body = BufferedBody.fromString("{param: 1}");
+    const body = new StringBody("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -39,7 +39,7 @@ describe("HttpRequestImpl", () => {
   });
 
   it("should replace headers", () => {
-    const body = BufferedBody.fromString("{param: 1}");
+    const body = new StringBody("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -63,35 +63,20 @@ describe("HttpRequestImpl", () => {
 
   it("should return query by queryName", () => {
     const url = "http://localhost?q=1&q=2&q=3";
-    const request = new HttpRequestImpl(
-      url,
-      BufferedBody.fromString(""),
-      "GET",
-      {}
-    );
+    const request = new HttpRequestImpl(url, new StringBody(""), "GET", {});
     expect(request.query("q")).toEqual(["1", "2", "3"]);
   });
 
   it("should add query", () => {
     const url = "http://localhost?q=1";
-    const request = new HttpRequestImpl(
-      url,
-      BufferedBody.fromString(""),
-      "GET",
-      {}
-    );
+    const request = new HttpRequestImpl(url, new StringBody(""), "GET", {});
     expect(request.addQuery("q2", "1").query("q2")).toEqual("1");
     expect(request.addQuery("q2", ["1", "2"]).query("q2")).toEqual(["1", "2"]);
   });
 
   it("should replace query", () => {
     const url = "http://localhost?q=1";
-    const request = new HttpRequestImpl(
-      url,
-      BufferedBody.fromString(""),
-      "GET",
-      {}
-    );
+    const request = new HttpRequestImpl(url, new StringBody(""), "GET", {});
     expect(request.replaceQuery("q", ["1", "2"]).query("q")).toEqual([
       "1",
       "2"
@@ -104,12 +89,7 @@ describe("HttpRequestImpl", () => {
 
   it("should remove query", () => {
     const url = "http://localhost?q=1&q2=2";
-    const request = new HttpRequestImpl(
-      url,
-      BufferedBody.fromString(""),
-      "GET",
-      {}
-    );
+    const request = new HttpRequestImpl(url, new StringBody(""), "GET", {});
     expect(request.removeQuery("q2").query("q2")).toEqual(undefined);
   });
 });

--- a/src/core/__tests__/HttpRequestImpl.spec.ts
+++ b/src/core/__tests__/HttpRequestImpl.spec.ts
@@ -1,9 +1,9 @@
 import { HttpRequestImpl } from "../HttpRequestImpl";
-import { HttpBodyImpl } from "../../node";
+import { BufferedBody } from "../../node";
 
 describe("HttpRequestImpl", () => {
   it("should add headers", () => {
-    const body = HttpBodyImpl.fromString("{param: 1}");
+    const body = BufferedBody.fromString("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -24,7 +24,7 @@ describe("HttpRequestImpl", () => {
   });
 
   it("should remove headers", () => {
-    const body = HttpBodyImpl.fromString("{param: 1}");
+    const body = BufferedBody.fromString("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -39,7 +39,7 @@ describe("HttpRequestImpl", () => {
   });
 
   it("should replace headers", () => {
-    const body = HttpBodyImpl.fromString("{param: 1}");
+    const body = BufferedBody.fromString("{param: 1}");
     const url = "http://localhost";
     const headers = {
       someHeader: "Some content",
@@ -65,7 +65,7 @@ describe("HttpRequestImpl", () => {
     const url = "http://localhost?q=1&q=2&q=3";
     const request = new HttpRequestImpl(
       url,
-      HttpBodyImpl.fromString(""),
+      BufferedBody.fromString(""),
       "GET",
       {}
     );
@@ -76,7 +76,7 @@ describe("HttpRequestImpl", () => {
     const url = "http://localhost?q=1";
     const request = new HttpRequestImpl(
       url,
-      HttpBodyImpl.fromString(""),
+      BufferedBody.fromString(""),
       "GET",
       {}
     );
@@ -88,7 +88,7 @@ describe("HttpRequestImpl", () => {
     const url = "http://localhost?q=1";
     const request = new HttpRequestImpl(
       url,
-      HttpBodyImpl.fromString(""),
+      BufferedBody.fromString(""),
       "GET",
       {}
     );
@@ -106,7 +106,7 @@ describe("HttpRequestImpl", () => {
     const url = "http://localhost?q=1&q2=2";
     const request = new HttpRequestImpl(
       url,
-      HttpBodyImpl.fromString(""),
+      BufferedBody.fromString(""),
       "GET",
       {}
     );

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,7 +1,12 @@
 export let TheTextDecoder: typeof TextDecoder;
+export let TheTextEncoder: typeof TextEncoder;
 
 // this technique does not work in real es6 environment because exported members are not mutable
 
-export function setupEnvironment(theTextDecoder: typeof TextDecoder) {
-  TheTextDecoder = theTextDecoder as typeof TextDecoder;
+export function setupEnvironment(
+  theTextDecoder: typeof TextDecoder,
+  theTextEncoder: typeof TextEncoder
+) {
+  TheTextDecoder = theTextDecoder;
+  TheTextEncoder = theTextEncoder;
 }

--- a/src/core/http-body/__tests__/buffered-body.spec.ts
+++ b/src/core/http-body/__tests__/buffered-body.spec.ts
@@ -1,4 +1,4 @@
-import { HttpBodyImpl, asJson } from "../HttpBodyImpl";
+import { BufferedBody, asJson } from "../buffered-body";
 
 async function* stringToIterable(content: string) {
   const data = [...content].map(ch => ch.charCodeAt(0));
@@ -12,21 +12,21 @@ describe("HttpBodyImpl", () => {
     const person = {
       name: "John"
     };
-    const body = HttpBodyImpl.fromString(JSON.stringify(person));
+    const body = BufferedBody.fromString(JSON.stringify(person));
 
     expect(await asJson(body)).toEqual(person);
   });
 
   it("should return string when created from a string", async () => {
     const content = "Some content";
-    const body = HttpBodyImpl.fromString(content);
+    const body = BufferedBody.fromString(content);
 
     expect(await body.asString("utf8")).toEqual(content);
   });
 
   it("should correctly decode iterable contents when converting to string", async () => {
     const it = stringToIterable("Hello");
-    const body = new HttpBodyImpl(it);
+    const body = new BufferedBody(it);
 
     expect(await body.asString()).toEqual("Hello");
   });

--- a/src/core/http-body/__tests__/buffered-body.spec.ts
+++ b/src/core/http-body/__tests__/buffered-body.spec.ts
@@ -1,27 +1,22 @@
 import { BufferedBody, asJson } from "../buffered-body";
-
-async function* stringToIterable(content: string) {
-  const data = [...content].map(ch => ch.charCodeAt(0));
-  for (const el of data) {
-    yield new Uint8Array([el]);
-  }
-}
+import { stringToIterable } from "../string-encoding-utils";
+import { StringBody } from "../string-body";
 
 describe("HttpBodyImpl", () => {
   it("asJson should return json", async () => {
     const person = {
       name: "John"
     };
-    const body = BufferedBody.fromString(JSON.stringify(person));
+    const body = new StringBody(JSON.stringify(person));
 
     expect(await asJson(body)).toEqual(person);
   });
 
   it("should return string when created from a string", async () => {
     const content = "Some content";
-    const body = BufferedBody.fromString(content);
+    const body = new StringBody(content);
 
-    expect(await body.asString("utf8")).toEqual(content);
+    expect(await body.asString()).toEqual(content);
   });
 
   it("should correctly decode iterable contents when converting to string", async () => {

--- a/src/core/http-body/__tests__/buffered-body.spec.ts
+++ b/src/core/http-body/__tests__/buffered-body.spec.ts
@@ -1,6 +1,7 @@
-import { BufferedBody, asJson } from "../buffered-body";
+import { BufferedBody } from "../buffered-body";
 import { stringToIterable } from "../string-encoding-utils";
 import { StringBody } from "../string-body";
+import { asJson } from "../helpers";
 
 describe("HttpBodyImpl", () => {
   it("asJson should return json", async () => {

--- a/src/core/http-body/__tests__/buffered-body.spec.ts
+++ b/src/core/http-body/__tests__/buffered-body.spec.ts
@@ -1,21 +1,20 @@
 import { BufferedBody } from "../buffered-body";
 import { stringToIterable } from "../string-encoding-utils";
-import { StringBody } from "../string-body";
-import { asJson } from "../helpers";
+import { asJson, stringBody } from "../helpers";
 
 describe("HttpBodyImpl", () => {
   it("asJson should return json", async () => {
     const person = {
       name: "John"
     };
-    const body = new StringBody(JSON.stringify(person));
+    const body = stringBody(JSON.stringify(person));
 
     expect(await asJson(body)).toEqual(person);
   });
 
   it("should return string when created from a string", async () => {
     const content = "Some content";
-    const body = new StringBody(content);
+    const body = stringBody(content);
 
     expect(await body.asString()).toEqual(content);
   });

--- a/src/core/http-body/__tests__/string-body.spec.ts
+++ b/src/core/http-body/__tests__/string-body.spec.ts
@@ -1,0 +1,20 @@
+import { StringBody } from "../string-body";
+import { BufferedBody } from "../../../node";
+
+describe("StringBody", () => {
+  it("should be a comparable HttpBody object", () => {
+    const body1 = new StringBody("any content");
+    const body2 = new StringBody("any content");
+
+    expect(body1).toEqual(body2);
+  });
+
+  it("should correctly convert to iterable", async () => {
+    const text = "Hello 😌";
+
+    const body = new StringBody(text);
+    const bufferedBody = new BufferedBody(body);
+
+    expect(await bufferedBody.asString()).toEqual(text);
+  });
+});

--- a/src/core/http-body/__tests__/string-body.spec.ts
+++ b/src/core/http-body/__tests__/string-body.spec.ts
@@ -1,10 +1,10 @@
-import { StringBody } from "../string-body";
 import { BufferedBody } from "../../../node";
+import { stringBody } from "../helpers";
 
 describe("StringBody", () => {
   it("should be a comparable HttpBody object", () => {
-    const body1 = new StringBody("any content");
-    const body2 = new StringBody("any content");
+    const body1 = stringBody("any content");
+    const body2 = stringBody("any content");
 
     expect(body1).toEqual(body2);
   });
@@ -12,7 +12,7 @@ describe("StringBody", () => {
   it("should correctly convert to iterable", async () => {
     const text = "Hello 😌";
 
-    const body = new StringBody(text);
+    const body = stringBody(text);
     const bufferedBody = new BufferedBody(body);
 
     expect(await bufferedBody.asString()).toEqual(text);

--- a/src/core/http-body/__tests__/string-encoding-utils.spec.ts
+++ b/src/core/http-body/__tests__/string-encoding-utils.spec.ts
@@ -1,0 +1,10 @@
+import { stringToIterable, iterableToString } from "../string-encoding-utils";
+
+describe("string-iterable conversions", () => {
+  it("should correctly convert string to iterable and vice versa", async () => {
+    const text = "Hello 😌";
+    const it = stringToIterable(text);
+
+    expect(await iterableToString(it)).toEqual(text);
+  });
+});

--- a/src/core/http-body/buffered-body.ts
+++ b/src/core/http-body/buffered-body.ts
@@ -1,7 +1,7 @@
-import { HttpBody } from "./http";
-import { TheTextDecoder } from "./env";
+import { HttpBody } from "../http";
+import { TheTextDecoder } from "../env";
 
-export class HttpBodyImpl implements HttpBody {
+export class BufferedBody implements HttpBody {
   constructor(private readonly it: AsyncIterable<Uint8Array>) {}
 
   async *[Symbol.asyncIterator]() {
@@ -26,7 +26,7 @@ export class HttpBodyImpl implements HttpBody {
       yield new Uint8Array(contentArr);
     }
 
-    return new HttpBodyImpl(gen());
+    return new BufferedBody(gen());
   }
 }
 
@@ -38,7 +38,7 @@ export async function asJson<T>(body: HttpBody): Promise<T> {
 
 export function jsonBody(obj: any) {
   const objStr = JSON.stringify(obj);
-  return HttpBodyImpl.fromString(objStr);
+  return BufferedBody.fromString(objStr);
 }
 
 // TODO: Move static function `fromString` out of Body and create StringBody and JsonBody classes

--- a/src/core/http-body/buffered-body.ts
+++ b/src/core/http-body/buffered-body.ts
@@ -1,6 +1,5 @@
 import { HttpBody } from "../http";
 import { iterableToString } from "./string-encoding-utils";
-import { StringBody } from "./string-body";
 
 export class BufferedBody implements HttpBody {
   constructor(private readonly it: AsyncIterable<Uint8Array>) {}
@@ -12,15 +11,4 @@ export class BufferedBody implements HttpBody {
   async asString(encoding = "utf8") {
     return iterableToString(this.it, encoding);
   }
-}
-
-export async function asJson<T>(body: HttpBody): Promise<T> {
-  const bodyToString = await body.asString();
-
-  return JSON.parse(bodyToString);
-}
-
-export function jsonBody(obj: any) {
-  const objStr = JSON.stringify(obj);
-  return new StringBody(objStr);
 }

--- a/src/core/http-body/buffered-body.ts
+++ b/src/core/http-body/buffered-body.ts
@@ -1,5 +1,6 @@
 import { HttpBody } from "../http";
-import { TheTextDecoder } from "../env";
+import { iterableToString } from "./string-encoding-utils";
+import { StringBody } from "./string-body";
 
 export class BufferedBody implements HttpBody {
   constructor(private readonly it: AsyncIterable<Uint8Array>) {}
@@ -9,24 +10,7 @@ export class BufferedBody implements HttpBody {
   }
 
   async asString(encoding = "utf8") {
-    const decoder = new TheTextDecoder(encoding);
-    let result = "";
-
-    for await (const iterator of this.it) {
-      result += decoder.decode(iterator, { stream: true });
-    }
-
-    return result;
-  }
-
-  public static fromString(content: string) {
-    const contentArr = [...content].map(ch => ch.charCodeAt(0));
-
-    async function* gen() {
-      yield new Uint8Array(contentArr);
-    }
-
-    return new BufferedBody(gen());
+    return iterableToString(this.it, encoding);
   }
 }
 
@@ -38,9 +22,5 @@ export async function asJson<T>(body: HttpBody): Promise<T> {
 
 export function jsonBody(obj: any) {
   const objStr = JSON.stringify(obj);
-  return BufferedBody.fromString(objStr);
+  return new StringBody(objStr);
 }
-
-// TODO: Move static function `fromString` out of Body and create StringBody and JsonBody classes
-// This can help us to compare body objects easier. See router tests for some examples.
-// Then create helper functions for creating body

--- a/src/core/http-body/helpers.ts
+++ b/src/core/http-body/helpers.ts
@@ -9,5 +9,9 @@ export async function asJson<T>(body: HttpBody): Promise<T> {
 
 export function jsonBody(obj: any) {
   const objStr = JSON.stringify(obj);
-  return new StringBody(objStr);
+  return stringBody(objStr);
+}
+
+export function stringBody(content: string) {
+  return new StringBody(content);
 }

--- a/src/core/http-body/helpers.ts
+++ b/src/core/http-body/helpers.ts
@@ -1,0 +1,13 @@
+import { HttpBody } from "../http";
+import { StringBody } from "./string-body";
+
+export async function asJson<T>(body: HttpBody): Promise<T> {
+  const bodyToString = await body.asString();
+
+  return JSON.parse(bodyToString);
+}
+
+export function jsonBody(obj: any) {
+  const objStr = JSON.stringify(obj);
+  return new StringBody(objStr);
+}

--- a/src/core/http-body/string-body.ts
+++ b/src/core/http-body/string-body.ts
@@ -1,0 +1,14 @@
+import { HttpBody } from "../http";
+import { stringToIterable } from "./string-encoding-utils";
+
+export class StringBody implements HttpBody {
+  constructor(private readonly content: string) {}
+
+  async asString(): Promise<string> {
+    return this.content;
+  }
+
+  async *[Symbol.asyncIterator]() {
+    yield* stringToIterable(this.content);
+  }
+}

--- a/src/core/http-body/string-encoding-utils.ts
+++ b/src/core/http-body/string-encoding-utils.ts
@@ -1,0 +1,20 @@
+import { TheTextDecoder, TheTextEncoder } from "../env";
+
+export async function* stringToIterable(content: string) {
+  const encoder = new TheTextEncoder();
+  yield encoder.encode(content);
+}
+
+export async function iterableToString(
+  it: AsyncIterable<Uint8Array>,
+  encoding = "utf8"
+) {
+  const decoder = new TheTextDecoder(encoding);
+  let result = "";
+
+  for await (const chunk of it) {
+    result += decoder.decode(chunk, { stream: true });
+  }
+
+  return result;
+}

--- a/src/core/mod.ts
+++ b/src/core/mod.ts
@@ -3,5 +3,6 @@ export * from "./http-status";
 export * from "./http";
 export * from "./http4ts";
 export * from "./http-body/buffered-body";
+export * from "./http-body/string-body";
 export * from "./HttpRequestImpl";
 export * from "./routing/routes";

--- a/src/core/mod.ts
+++ b/src/core/mod.ts
@@ -4,5 +4,6 @@ export * from "./http";
 export * from "./http4ts";
 export * from "./http-body/buffered-body";
 export * from "./http-body/string-body";
+export * from "./http-body/helpers";
 export * from "./HttpRequestImpl";
 export * from "./routing/routes";

--- a/src/core/mod.ts
+++ b/src/core/mod.ts
@@ -2,6 +2,6 @@ export * from "./env";
 export * from "./http-status";
 export * from "./http";
 export * from "./http4ts";
-export * from "./HttpBodyImpl";
+export * from "./http-body/buffered-body";
 export * from "./HttpRequestImpl";
 export * from "./routing/routes";

--- a/src/core/routing/__tests__/routes.spec.ts
+++ b/src/core/routing/__tests__/routes.spec.ts
@@ -19,18 +19,6 @@ function request(url: string, body: string, method: HttpMethod): HttpRequest {
   return new HttpRequestImpl(url, stringBody(body), method);
 }
 
-async function assertResponseEquality(
-  actual: HttpResponse,
-  expected: HttpResponse
-) {
-  const actualBody = await actual.body.asString();
-  const expectedBody = await expected.body.asString();
-
-  expect(actualBody).toEqual(expectedBody);
-  expect(actual.headers).toEqual(expected.headers);
-  expect(actual.status).toEqual(expected.status);
-}
-
 describe("routes", () => {
   const slash = () => resp(200, "slash");
   const home = () => resp(200, "home");
@@ -55,58 +43,55 @@ describe("routes", () => {
   test("GET / should return slash handler", async () => {
     const req = request("/", "somebody", "GET");
 
-    await assertResponseEquality(await routingHandler(req), slash());
+    expect(await routingHandler(req)).toEqual(slash());
   });
 
   test("GET /home should return home handler", async () => {
     const req = request("/home", "somebody", "GET");
 
-    await assertResponseEquality(await routingHandler(req), home());
+    expect(await routingHandler(req)).toEqual(home());
   });
 
   test("GET /articles/1 should return articles handler", async () => {
     const req = request("/articles/1", "somebody", "GET");
 
-    await assertResponseEquality(await routingHandler(req), resp(200, "1"));
+    expect(await routingHandler(req)).toEqual(resp(200, "1"));
   });
 
   test("GET /company should return not found", async () => {
     const req = request("/company", "somebody", "GET");
 
-    await assertResponseEquality(await routingHandler(req), nf());
+    expect(await routingHandler(req)).toEqual(nf());
   });
 
   test("GET /company/carriers should return carriers handler", async () => {
     const req = request("/company/carriers", "somebody", "GET");
 
-    await assertResponseEquality(await routingHandler(req), carriers());
+    expect(await routingHandler(req)).toEqual(carriers());
   });
 
   test("GET /company/contacts should return contacts handler", async () => {
     const req = request("/company/contacts", "somebody", "GET");
 
-    await assertResponseEquality(await routingHandler(req), contacts());
+    expect(await routingHandler(req)).toEqual(contacts());
   });
 
   test("notFound handler should be called when there is no matched route", async () => {
     const req = request("/company/about", "somebody", "GET");
 
-    await assertResponseEquality(await routingHandler(req), nf());
+    expect(await routingHandler(req)).toEqual(nf());
   });
 
   test("POST /submit-contact should return submitContact", async () => {
     const req = request("/submit-contact", "somebody", "POST");
 
-    await assertResponseEquality(await routingHandler(req), submitContact());
+    expect(await routingHandler(req)).toEqual(submitContact());
   });
 
   test("POST and GET /all-methods should return allMethods", async () => {
     const postReq = request("/all-methods", "some form data", "POST");
 
-    await assertResponseEquality(
-      await routingHandler(postReq),
-      allMethods(postReq)
-    );
+    expect(await routingHandler(postReq)).toEqual(allMethods(postReq));
 
     const getReq = new HttpRequestImpl(
       postReq.url,
@@ -114,9 +99,7 @@ describe("routes", () => {
       "GET",
       postReq.headers
     );
-    await assertResponseEquality(
-      await routingHandler(getReq),
-      allMethods(getReq)
-    );
+
+    expect(await routingHandler(getReq)).toEqual(allMethods(getReq));
   });
 });

--- a/src/core/routing/__tests__/routes.spec.ts
+++ b/src/core/routing/__tests__/routes.spec.ts
@@ -1,7 +1,7 @@
 import { HttpHeaders, HttpRequest, HttpResponse, HttpMethod } from "../../http";
 import { routes, get, notFound, RoutedHttpRequest, post, all } from "../routes";
 import { HttpRequestImpl } from "../../HttpRequestImpl";
-import { StringBody } from "../../http-body/string-body";
+import { stringBody } from "../../http-body/helpers";
 
 function resp(
   status = 200,
@@ -10,13 +10,13 @@ function resp(
 ): HttpResponse {
   return {
     status,
-    body: new StringBody(body),
+    body: stringBody(body),
     headers
   };
 }
 
 function request(url: string, body: string, method: HttpMethod): HttpRequest {
-  return new HttpRequestImpl(url, new StringBody(body), method);
+  return new HttpRequestImpl(url, stringBody(body), method);
 }
 
 async function assertResponseEquality(

--- a/src/core/routing/__tests__/routes.spec.ts
+++ b/src/core/routing/__tests__/routes.spec.ts
@@ -1,7 +1,7 @@
 import { HttpHeaders, HttpRequest, HttpResponse, HttpMethod } from "../../http";
 import { routes, get, notFound, RoutedHttpRequest, post, all } from "../routes";
 import { HttpRequestImpl } from "../../HttpRequestImpl";
-import { BufferedBody } from "../../http-body/buffered-body";
+import { StringBody } from "../../http-body/string-body";
 
 function resp(
   status = 200,
@@ -10,13 +10,13 @@ function resp(
 ): HttpResponse {
   return {
     status,
-    body: BufferedBody.fromString(body),
+    body: new StringBody(body),
     headers
   };
 }
 
 function request(url: string, body: string, method: HttpMethod): HttpRequest {
-  return new HttpRequestImpl(url, BufferedBody.fromString(body), method);
+  return new HttpRequestImpl(url, new StringBody(body), method);
 }
 
 async function assertResponseEquality(

--- a/src/core/routing/__tests__/routes.spec.ts
+++ b/src/core/routing/__tests__/routes.spec.ts
@@ -1,7 +1,7 @@
 import { HttpHeaders, HttpRequest, HttpResponse, HttpMethod } from "../../http";
 import { routes, get, notFound, RoutedHttpRequest, post, all } from "../routes";
 import { HttpRequestImpl } from "../../HttpRequestImpl";
-import { HttpBodyImpl } from "../../HttpBodyImpl";
+import { BufferedBody } from "../../http-body/buffered-body";
 
 function resp(
   status = 200,
@@ -10,13 +10,13 @@ function resp(
 ): HttpResponse {
   return {
     status,
-    body: HttpBodyImpl.fromString(body),
+    body: BufferedBody.fromString(body),
     headers
   };
 }
 
 function request(url: string, body: string, method: HttpMethod): HttpRequest {
-  return new HttpRequestImpl(url, HttpBodyImpl.fromString(body), method);
+  return new HttpRequestImpl(url, BufferedBody.fromString(body), method);
 }
 
 async function assertResponseEquality(

--- a/src/core/routing/routes.ts
+++ b/src/core/routing/routes.ts
@@ -1,7 +1,7 @@
 import { HttpMethod, HttpRequest, HttpResponse } from "../http";
 import { HttpHandler } from "../http4ts";
 import { pathToRegexp, Key } from "./path-to-regexp";
-import { BufferedBody } from "../http-body/buffered-body";
+import { StringBody } from "../http-body/string-body";
 
 export interface RoutedHttpRequest extends HttpRequest {
   routeParams: Record<string, string>;
@@ -22,7 +22,7 @@ interface RouteDefinition {
 
 function defaultNotFoundHandler(): HttpResponse {
   return {
-    body: BufferedBody.fromString("Not Found"),
+    body: new StringBody("Not Found"),
     headers: {},
     status: 404
   };

--- a/src/core/routing/routes.ts
+++ b/src/core/routing/routes.ts
@@ -1,7 +1,7 @@
 import { HttpMethod, HttpRequest, HttpResponse } from "../http";
 import { HttpHandler } from "../http4ts";
 import { pathToRegexp, Key } from "./path-to-regexp";
-import { StringBody } from "../http-body/string-body";
+import { stringBody } from "../http-body/helpers";
 
 export interface RoutedHttpRequest extends HttpRequest {
   routeParams: Record<string, string>;
@@ -22,7 +22,7 @@ interface RouteDefinition {
 
 function defaultNotFoundHandler(): HttpResponse {
   return {
-    body: new StringBody("Not Found"),
+    body: stringBody("Not Found"),
     headers: {},
     status: 404
   };

--- a/src/core/routing/routes.ts
+++ b/src/core/routing/routes.ts
@@ -1,7 +1,7 @@
 import { HttpMethod, HttpRequest, HttpResponse } from "../http";
 import { HttpHandler } from "../http4ts";
 import { pathToRegexp, Key } from "./path-to-regexp";
-import { HttpBodyImpl } from "../HttpBodyImpl";
+import { BufferedBody } from "../http-body/buffered-body";
 
 export interface RoutedHttpRequest extends HttpRequest {
   routeParams: Record<string, string>;
@@ -22,7 +22,7 @@ interface RouteDefinition {
 
 function defaultNotFoundHandler(): HttpResponse {
   return {
-    body: HttpBodyImpl.fromString("Not Found"),
+    body: BufferedBody.fromString("Not Found"),
     headers: {},
     status: 404
   };

--- a/src/examples/simple-node-server.ts
+++ b/src/examples/simple-node-server.ts
@@ -4,14 +4,14 @@ import {
   HttpRequest,
   HttpResponse,
   HttpStatus,
-  toNodeRequestListener,
-  BufferedBody
+  toNodeRequestListener
 } from "../node";
+import { StringBody } from "../core/http-body/string-body";
 
 async function handler(req: HttpRequest): Promise<HttpResponse> {
   await req.body.asString("UTF-8");
   return {
-    body: BufferedBody.fromString("This is some string"),
+    body: new StringBody("This is some string"),
     headers: {},
     status: HttpStatus.OK
   };

--- a/src/examples/simple-node-server.ts
+++ b/src/examples/simple-node-server.ts
@@ -5,13 +5,13 @@ import {
   HttpResponse,
   HttpStatus,
   toNodeRequestListener,
-  HttpBodyImpl
+  BufferedBody
 } from "../node";
 
 async function handler(req: HttpRequest): Promise<HttpResponse> {
   await req.body.asString("UTF-8");
   return {
-    body: HttpBodyImpl.fromString("This is some string"),
+    body: BufferedBody.fromString("This is some string"),
     headers: {},
     status: HttpStatus.OK
   };

--- a/src/examples/simple-node-server.ts
+++ b/src/examples/simple-node-server.ts
@@ -5,13 +5,13 @@ import {
   HttpResponse,
   HttpStatus,
   toNodeRequestListener,
-  StringBody
+  stringBody
 } from "../node";
 
 async function handler(req: HttpRequest): Promise<HttpResponse> {
   await req.body.asString("UTF-8");
   return {
-    body: new StringBody("This is some string"),
+    body: stringBody("This is some string"),
     headers: {},
     status: HttpStatus.OK
   };

--- a/src/examples/simple-node-server.ts
+++ b/src/examples/simple-node-server.ts
@@ -4,9 +4,9 @@ import {
   HttpRequest,
   HttpResponse,
   HttpStatus,
-  toNodeRequestListener
+  toNodeRequestListener,
+  StringBody
 } from "../node";
-import { StringBody } from "../core/http-body/string-body";
 
 async function handler(req: HttpRequest): Promise<HttpResponse> {
   await req.body.asString("UTF-8");

--- a/src/node/__tests__/server.spec.ts
+++ b/src/node/__tests__/server.spec.ts
@@ -3,8 +3,9 @@ import { get, post } from "request-promise";
 import { HttpResponse } from "../../core/http";
 import { toNodeRequestListener } from "../server";
 import { HttpHandler } from "../../core/http4ts";
-import { BufferedBody, jsonBody } from "../../core/http-body/buffered-body";
+import { BufferedBody } from "../../core/http-body/buffered-body";
 import { StringBody } from "../../core/http-body/string-body";
+import { jsonBody } from "../../core/http-body/helpers";
 
 async function runOnTestServer(
   handler: HttpHandler,

--- a/src/node/__tests__/server.spec.ts
+++ b/src/node/__tests__/server.spec.ts
@@ -3,7 +3,7 @@ import { get } from "request-promise";
 import { HttpResponse } from "../../core/http";
 import { toNodeRequestListener } from "../server";
 import { HttpHandler } from "../../core/http4ts";
-import { HttpBodyImpl, jsonBody } from "../../core/HttpBodyImpl";
+import { BufferedBody, jsonBody } from "../../core/http-body/buffered-body";
 
 async function runOnTestServer(
   handler: HttpHandler,
@@ -69,7 +69,7 @@ describe("node server binding", () => {
     const handler: HttpHandler = async () => {
       return new Promise<HttpResponse>(resolve => {
         const res = {
-          body: HttpBodyImpl.fromString("1 second passed!"),
+          body: BufferedBody.fromString("1 second passed!"),
           status: 200,
           headers: {}
         };
@@ -100,7 +100,7 @@ describe("node server binding", () => {
     const handler: HttpHandler = async () => {
       return new Promise<HttpResponse>(resolve => {
         const res = {
-          body: new HttpBodyImpl(bodyGenerator()),
+          body: new BufferedBody(bodyGenerator()),
           status: 200,
           headers: {}
         };
@@ -136,7 +136,7 @@ describe("node server binding", () => {
     const handler: HttpHandler = async () => {
       return new Promise<HttpResponse>(resolve => {
         const res = {
-          body: new HttpBodyImpl(bodyGenerator()),
+          body: new BufferedBody(bodyGenerator()),
           status: 200,
           headers: {}
         };

--- a/src/node/__tests__/server.spec.ts
+++ b/src/node/__tests__/server.spec.ts
@@ -4,8 +4,7 @@ import { HttpResponse } from "../../core/http";
 import { toNodeRequestListener } from "../server";
 import { HttpHandler } from "../../core/http4ts";
 import { BufferedBody } from "../../core/http-body/buffered-body";
-import { StringBody } from "../../core/http-body/string-body";
-import { jsonBody } from "../../core/http-body/helpers";
+import { jsonBody, stringBody } from "../../core/http-body/helpers";
 
 async function runOnTestServer(
   handler: HttpHandler,
@@ -71,7 +70,7 @@ describe("node server binding", () => {
     const handler: HttpHandler = async () => {
       return new Promise<HttpResponse>(resolve => {
         const res = {
-          body: new StringBody("1 second passed!"),
+          body: stringBody("1 second passed!"),
           status: 200,
           headers: {}
         };
@@ -162,7 +161,7 @@ describe("node server binding", () => {
     const handler: HttpHandler = async req => {
       expect(await req.body.asString()).toEqual("Hello 😌");
       return {
-        body: new StringBody("Bye 😌"),
+        body: stringBody("Bye 😌"),
         headers: {},
         status: 200
       };

--- a/src/node/__tests__/server.spec.ts
+++ b/src/node/__tests__/server.spec.ts
@@ -1,9 +1,10 @@
 import * as http from "http";
-import { get } from "request-promise";
+import { get, post } from "request-promise";
 import { HttpResponse } from "../../core/http";
 import { toNodeRequestListener } from "../server";
 import { HttpHandler } from "../../core/http4ts";
 import { BufferedBody, jsonBody } from "../../core/http-body/buffered-body";
+import { StringBody } from "../../core/http-body/string-body";
 
 async function runOnTestServer(
   handler: HttpHandler,
@@ -69,11 +70,11 @@ describe("node server binding", () => {
     const handler: HttpHandler = async () => {
       return new Promise<HttpResponse>(resolve => {
         const res = {
-          body: BufferedBody.fromString("1 second passed!"),
+          body: new StringBody("1 second passed!"),
           status: 200,
           headers: {}
         };
-        setTimeout(() => resolve(res), 1000);
+        setTimeout(() => resolve(res), 100);
       });
     };
 
@@ -104,7 +105,7 @@ describe("node server binding", () => {
           status: 200,
           headers: {}
         };
-        setTimeout(() => resolve(res), 1000);
+        setTimeout(() => resolve(res), 100);
       });
     };
 
@@ -140,7 +141,7 @@ describe("node server binding", () => {
           status: 200,
           headers: {}
         };
-        setTimeout(() => resolve(res), 1000);
+        setTimeout(() => resolve(res), 100);
       });
     };
 
@@ -153,6 +154,28 @@ describe("node server binding", () => {
       // Since the error happens after setting the response statusCode and headers, we don't see 500 in statusCode
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual("He");
+    });
+  });
+
+  it("should handle requests with unicode body", async () => {
+    const handler: HttpHandler = async req => {
+      expect(await req.body.asString()).toEqual("Hello 😌");
+      return {
+        body: new StringBody("Bye 😌"),
+        headers: {},
+        status: 200
+      };
+    };
+
+    await runOnTestServer(handler, async () => {
+      const res = await post("http://localhost:8080/", {
+        body: "Hello 😌",
+        simple: false,
+        resolveWithFullResponse: true
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual("Bye 😌");
     });
   });
 });

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -1,5 +1,4 @@
 import { RequestListener, IncomingMessage, ServerResponse } from "http";
-import { TextDecoder } from "util";
 import { once } from "events";
 import * as util from "util";
 import * as stream from "stream";
@@ -45,7 +44,7 @@ async function writeErrorResponse(nodeRes: ServerResponse) {
 }
 
 export function toNodeRequestListener(handler: HttpHandler): RequestListener {
-  setupEnvironment(TextDecoder as any);
+  setupEnvironment(util.TextDecoder as any, util.TextEncoder as any);
 
   return async (req, res) => {
     try {

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -9,14 +9,14 @@ import { HttpRequest, HttpResponse } from "../core/http";
 import { HttpStatus } from "../core/http-status";
 import { HttpRequestImpl } from "../core/HttpRequestImpl";
 import { setupEnvironment } from "../core/env";
-import { HttpBodyImpl } from "../core/HttpBodyImpl";
+import { BufferedBody } from "../core/http-body/buffered-body";
 
 const finished = util.promisify(stream.finished);
 
 function toHttp4tsRequest(nodeReq: IncomingMessage): HttpRequest {
   return new HttpRequestImpl(
     nodeReq.url || "", // TODO: Maybe failing is better
-    new HttpBodyImpl(nodeReq),
+    new BufferedBody(nodeReq),
     nodeReq.method || "", // TODO: Maybe failing is better
     nodeReq.headers
   );


### PR DESCRIPTION
**The branch is created on top of `api-imporvements`. Please first review [this PR](https://github.com/http4ts/http4ts/pull/47).**

In this PR, I have improved http-body:

* Separated json serialization from body. There are standalone helper functions for creating and parsing json bodies. Next step would be to create a function that adds json body to response with the correct content-type header.
* Created `StringBody` class. This class has a private string field called `content`. This class performs better in tests when comparing body objects.
* Created a couple of helper functions to work with bodies (see `helpers.ts`).