### PR TITLE
Http method enum

### DIFF
--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -7,17 +7,19 @@ export interface HttpHeaders {
 
 export type HttpQuery = string | string[] | undefined | null;
 
-export type HttpMethod =
-  | "GET"
-  | "POST"
-  | "PUT"
-  | "DELETE"
-  | "OPTIONS"
-  | "TRACE"
-  | "PATCH"
-  | "PURGE"
-  | "HEAD"
-  | string;
+export enum HttpMethods {
+  GET = "GET",
+  POST = "POST",
+  PUT = "PUT",
+  DELETE = "DELETE",
+  OPTIONS = "OPTIONS",
+  TRACE = "TRACE",
+  PATCH = "PATCH",
+  PURGE = "PURGE",
+  HEAD = "HEAD"
+}
+
+export type HttpMethod = HttpMethods | string;
 
 export interface HttpBody extends AsyncIterable<Uint8Array> {
   asString: (encoding?: string) => Promise<string>;

--- a/src/core/routing/__tests__/routes.spec.ts
+++ b/src/core/routing/__tests__/routes.spec.ts
@@ -1,4 +1,10 @@
-import { HttpHeaders, HttpRequest, HttpResponse, HttpMethod } from "../../http";
+import {
+  HttpHeaders,
+  HttpRequest,
+  HttpResponse,
+  HttpMethod,
+  HttpMethods
+} from "../../http";
 import { routes, get, notFound, RoutedHttpRequest, post, all } from "../routes";
 import { HttpRequestImpl } from "../../HttpRequestImpl";
 import { stringBody } from "../../http-body/helpers";
@@ -83,13 +89,13 @@ describe("routes", () => {
   });
 
   test("POST /submit-contact should return submitContact", async () => {
-    const req = request("/submit-contact", "somebody", "POST");
+    const req = request("/submit-contact", "somebody", HttpMethods.POST);
 
     expect(await routingHandler(req)).toEqual(submitContact());
   });
 
   test("POST and GET /all-methods should return allMethods", async () => {
-    const postReq = request("/all-methods", "some form data", "POST");
+    const postReq = request("/all-methods", "some form data", HttpMethods.POST);
 
     expect(await routingHandler(postReq)).toEqual(allMethods(postReq));
 

--- a/src/core/routing/routes.ts
+++ b/src/core/routing/routes.ts
@@ -1,7 +1,8 @@
-import { HttpMethod, HttpRequest, HttpResponse } from "../http";
+import { HttpMethod, HttpRequest, HttpResponse, HttpMethods } from "../http";
 import { HttpHandler } from "../http4ts";
 import { pathToRegexp, Key } from "./path-to-regexp";
 import { stringBody } from "../http-body/helpers";
+import { HttpStatus } from "../../node";
 
 export interface RoutedHttpRequest extends HttpRequest {
   routeParams: Record<string, string>;
@@ -24,7 +25,7 @@ function defaultNotFoundHandler(): HttpResponse {
   return {
     body: stringBody("Not Found"),
     headers: {},
-    status: 404
+    status: HttpStatus.NOT_FOUND
   };
 }
 export function routes(
@@ -109,7 +110,7 @@ export function post(
   path: UriTemplate,
   handler: RoutedHttpHandler
 ): RouteDefinition {
-  return route("POST", path, handler);
+  return route(HttpMethods.POST, path, handler);
 }
 
 export function notFound(handler: RoutedHttpHandler): RouteDefinition {


### PR DESCRIPTION
This PR adds an `enum` to provide better intellisense experience when working with httpMethods.