### PR TITLE
API docs created using Typedoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2707,6 +2707,17 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2847,6 +2858,19 @@
       "dev": true,
       "optional": true
     },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2942,6 +2966,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
+      "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==",
       "dev": true
     },
     "hosted-git-info": {
@@ -3130,6 +3160,12 @@
           }
         }
       }
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -4047,6 +4083,15 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4630,6 +4675,12 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "lunr": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4668,6 +4719,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -4792,6 +4849,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nice-try": {
@@ -5387,6 +5450,15 @@
       "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
       "dev": true
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
@@ -5901,6 +5973,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -6630,11 +6713,67 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
+      "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.0.0",
+        "lodash": "^4.17.15",
+        "lunr": "^2.3.8",
+        "marked": "1.0.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.10.1"
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz",
+      "integrity": "sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.8"
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.2.17.tgz",
+      "integrity": "sha512-eE6cTeqsZIbjur6RG91Lhx1vTwjR49OHwVPRlmsxY3dthS4FNRL8sHxT5Y9pkosBwv1kSmNGQEPHjMYy1Ag6DQ==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.3"
+      }
+    },
     "typescript": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
+      "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "undefsafe": {
       "version": "2.0.3",
@@ -6682,6 +6821,12 @@
       "requires": {
         "crypto-random-string": "^2.0.0"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -6921,6 +7066,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "deno-example": "npm run deno-prebuild-core && deno run --allow-net src/deno/examples/example.ts",
     "deno-example-client": "npm run deno-prebuild-core && deno run --allow-net src/deno/examples/example-client.ts",
     "deno-prebuild-core": "deno run --allow-read --allow-write src/deno/scripts/deno-prebuild.ts --in src/core --out src/deno/core",
-    "deno-test": "deno test --allow-net src/deno/"
+    "deno-test": "deno test --allow-net src/deno/",
+    "typedoc": "rm -Rf ./website/docs/api && typedoc && rm -Rf ./website/website/"
   },
   "repository": {
     "type": "git",
@@ -48,6 +49,8 @@
     "request-promise": "^4.2.5",
     "ts-jest": "^25.4.0",
     "ts-node": "^8.9.0",
+    "typedoc": "^0.17.7",
+    "typedoc-plugin-markdown": "^2.2.17",
     "typescript": "^3.8.3"
   },
   "jest": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,26 @@
     "declaration": true,
     "strict": true
   },
-  "exclude": ["node_modules", "dist", "src/deno"]
+  "exclude": ["node_modules", "dist", "src/deno"],
+  "typedocOptions": {
+    "inputFiles": ["./src/core"],
+    "out": "./website/docs/api",
+    "mode": "file",
+    "plugin": "typedoc-plugin-markdown",
+    "theme": "docusaurus2",
+    "skipSidebar": "true",
+    "includeDeclarations": true,
+    "excludeExternals": true,
+    "excludeNotExported": true,
+    "excludePrivate": true,
+    "stripInternal": true,
+    "includeVersion": true,
+    "readme": "none",
+    "target": "ES6",
+    "exclude": [
+      "**/node_modules/**",
+      "**/__tests__/**",
+      "**/jest/**"
+    ]
+  }
 }

--- a/website/docs/api/classes/bufferedbody.md
+++ b/website/docs/api/classes/bufferedbody.md
@@ -1,0 +1,70 @@
+---
+id: "bufferedbody"
+title: "BufferedBody"
+sidebar_label: "BufferedBody"
+---
+
+[http4ts - v0.0.3](../index.md) › [BufferedBody](bufferedbody.md)
+
+## Hierarchy
+
+* **BufferedBody**
+
+## Implements
+
+* [HttpBody](../interfaces/httpbody.md)
+
+## Index
+
+### Constructors
+
+* [constructor](bufferedbody.md#constructor)
+
+### Methods
+
+* [[Symbol.asyncIterator]](bufferedbody.md#[symbol.asynciterator])
+* [asString](bufferedbody.md#asstring)
+
+## Constructors
+
+###  constructor
+
+\+ **new BufferedBody**(`it`: AsyncIterable‹Uint8Array | string›): *[BufferedBody](bufferedbody.md)*
+
+Defined in src/core/http-body/buffered-body.ts:4
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`it` | AsyncIterable‹Uint8Array &#124; string› |
+
+**Returns:** *[BufferedBody](bufferedbody.md)*
+
+## Methods
+
+###  [Symbol.asyncIterator]
+
+▸ **[Symbol.asyncIterator]**(): *AsyncGenerator‹string | Uint8Array‹›, void, undefined›*
+
+*Implementation of [HttpBody](../interfaces/httpbody.md)*
+
+Defined in src/core/http-body/buffered-body.ts:7
+
+**Returns:** *AsyncGenerator‹string | Uint8Array‹›, void, undefined›*
+
+___
+
+###  asString
+
+▸ **asString**(`encoding`: string): *Promise‹string›*
+
+Defined in src/core/http-body/buffered-body.ts:11
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`encoding` | string | "utf8" |
+
+**Returns:** *Promise‹string›*

--- a/website/docs/api/classes/httprequestimpl.md
+++ b/website/docs/api/classes/httprequestimpl.md
@@ -1,0 +1,292 @@
+---
+id: "httprequestimpl"
+title: "HttpRequestImpl"
+sidebar_label: "HttpRequestImpl"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpRequestImpl](httprequestimpl.md)
+
+## Hierarchy
+
+* **HttpRequestImpl**
+
+## Implements
+
+* [HttpRequest](../interfaces/httprequest.md)
+
+## Index
+
+### Constructors
+
+* [constructor](httprequestimpl.md#constructor)
+
+### Properties
+
+* [body](httprequestimpl.md#readonly-body)
+* [headers](httprequestimpl.md#readonly-headers)
+* [method](httprequestimpl.md#readonly-method)
+* [url](httprequestimpl.md#readonly-url)
+
+### Methods
+
+* [addHeader](httprequestimpl.md#addheader)
+* [addQuery](httprequestimpl.md#addquery)
+* [path](httprequestimpl.md#path)
+* [query](httprequestimpl.md#query)
+* [removeHeader](httprequestimpl.md#removeheader)
+* [removeQuery](httprequestimpl.md#removequery)
+* [replaceHeader](httprequestimpl.md#replaceheader)
+* [replaceQuery](httprequestimpl.md#replacequery)
+* [setBody](httprequestimpl.md#setbody)
+* [setHeaders](httprequestimpl.md#setheaders)
+* [setMethod](httprequestimpl.md#setmethod)
+* [setUrl](httprequestimpl.md#seturl)
+
+## Constructors
+
+###  constructor
+
+\+ **new HttpRequestImpl**(`url`: string, `method`: [HttpMethod](../index.md#httpmethod), `body`: [HttpBody](../interfaces/httpbody.md), `headers`: [RequestHttpHeaders](../interfaces/requesthttpheaders.md)): *[HttpRequestImpl](httprequestimpl.md)*
+
+Defined in src/core/http-request/http-request-impl.ts:10
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`url` | string |
+`method` | [HttpMethod](../index.md#httpmethod) |
+`body` | [HttpBody](../interfaces/httpbody.md) |
+`headers` | [RequestHttpHeaders](../interfaces/requesthttpheaders.md) |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)*
+
+## Properties
+
+### `Readonly` body
+
+• **body**: *[HttpBody](../interfaces/httpbody.md)*
+
+*Implementation of [HttpRequest](../interfaces/httprequest.md).[body](../interfaces/httprequest.md#body)*
+
+Defined in src/core/http-request/http-request-impl.ts:15
+
+___
+
+### `Readonly` headers
+
+• **headers**: *[RequestHttpHeaders](../interfaces/requesthttpheaders.md)*
+
+*Implementation of [HttpRequest](../interfaces/httprequest.md).[headers](../interfaces/httprequest.md#headers)*
+
+Defined in src/core/http-request/http-request-impl.ts:16
+
+___
+
+### `Readonly` method
+
+• **method**: *[HttpMethod](../index.md#httpmethod)*
+
+*Implementation of [HttpRequest](../interfaces/httprequest.md).[method](../interfaces/httprequest.md#method)*
+
+Defined in src/core/http-request/http-request-impl.ts:14
+
+___
+
+### `Readonly` url
+
+• **url**: *string*
+
+*Implementation of [HttpRequest](../interfaces/httprequest.md).[url](../interfaces/httprequest.md#url)*
+
+Defined in src/core/http-request/http-request-impl.ts:13
+
+## Methods
+
+###  addHeader
+
+▸ **addHeader**(`header`: keyof RequestHttpHeaders, `value`: string | string[]): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:30
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof RequestHttpHeaders |
+`value` | string &#124; string[] |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  addQuery
+
+▸ **addQuery**(`name`: string, `value`: string | string[]): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:83
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | string &#124; string[] |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  path
+
+▸ **path**(): *string*
+
+Defined in src/core/http-request/http-request-impl.ts:128
+
+**Returns:** *string*
+
+___
+
+###  query
+
+▸ **query**(`name`: string): *undefined | string | string[]*
+
+Defined in src/core/http-request/http-request-impl.ts:72
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *undefined | string | string[]*
+
+___
+
+###  removeHeader
+
+▸ **removeHeader**(`headerToRemove`: keyof RequestHttpHeaders): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:52
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`headerToRemove` | keyof RequestHttpHeaders |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  removeQuery
+
+▸ **removeQuery**(`queryToRemove`: string): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:99
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`queryToRemove` | string |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  replaceHeader
+
+▸ **replaceHeader**(`header`: keyof RequestHttpHeaders, `value`: string | string[]): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:41
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof RequestHttpHeaders |
+`value` | string &#124; string[] |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  replaceQuery
+
+▸ **replaceQuery**(`name`: string, `value`: string | string[]): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:111
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | string &#124; string[] |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  setBody
+
+▸ **setBody**(`body`: [HttpBody](../interfaces/httpbody.md) | string): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:132
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`body` | [HttpBody](../interfaces/httpbody.md) &#124; string |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  setHeaders
+
+▸ **setHeaders**(`headers`: [RequestHttpHeaders](../interfaces/requesthttpheaders.md)): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:26
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`headers` | [RequestHttpHeaders](../interfaces/requesthttpheaders.md) |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  setMethod
+
+▸ **setMethod**(`method`: [HttpMethod](../index.md#httpmethod)): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:138
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`method` | [HttpMethod](../index.md#httpmethod) |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+___
+
+###  setUrl
+
+▸ **setUrl**(`url`: string): *[HttpRequestImpl](httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/http-request-impl.ts:68
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`url` | string |
+
+**Returns:** *[HttpRequestImpl](httprequestimpl.md)‹›*

--- a/website/docs/api/classes/httpresponseimpl.md
+++ b/website/docs/api/classes/httpresponseimpl.md
@@ -1,0 +1,182 @@
+---
+id: "httpresponseimpl"
+title: "HttpResponseImpl"
+sidebar_label: "HttpResponseImpl"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpResponseImpl](httpresponseimpl.md)
+
+## Hierarchy
+
+* **HttpResponseImpl**
+
+## Implements
+
+* [HttpResponse](../interfaces/httpresponse.md)
+
+## Index
+
+### Constructors
+
+* [constructor](httpresponseimpl.md#constructor)
+
+### Properties
+
+* [body](httpresponseimpl.md#readonly-body)
+* [headers](httpresponseimpl.md#readonly-headers)
+* [status](httpresponseimpl.md#readonly-status)
+
+### Methods
+
+* [addHeader](httpresponseimpl.md#addheader)
+* [removeHeader](httpresponseimpl.md#removeheader)
+* [replaceHeader](httpresponseimpl.md#replaceheader)
+* [setBody](httpresponseimpl.md#setbody)
+* [setHeaders](httpresponseimpl.md#setheaders)
+* [setStatus](httpresponseimpl.md#setstatus)
+
+## Constructors
+
+###  constructor
+
+\+ **new HttpResponseImpl**(`status`: [HttpStatus](../enums/httpstatus.md), `body`: [HttpBody](../interfaces/httpbody.md), `headers`: [ResponseHttpHeaders](../interfaces/responsehttpheaders.md)): *[HttpResponseImpl](httpresponseimpl.md)*
+
+Defined in src/core/http-response/http-response-impl.ts:5
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`status` | [HttpStatus](../enums/httpstatus.md) |
+`body` | [HttpBody](../interfaces/httpbody.md) |
+`headers` | [ResponseHttpHeaders](../interfaces/responsehttpheaders.md) |
+
+**Returns:** *[HttpResponseImpl](httpresponseimpl.md)*
+
+## Properties
+
+### `Readonly` body
+
+• **body**: *[HttpBody](../interfaces/httpbody.md)*
+
+*Implementation of [HttpResponse](../interfaces/httpresponse.md).[body](../interfaces/httpresponse.md#body)*
+
+Defined in src/core/http-response/http-response-impl.ts:8
+
+___
+
+### `Readonly` headers
+
+• **headers**: *[ResponseHttpHeaders](../interfaces/responsehttpheaders.md)*
+
+*Implementation of [HttpResponse](../interfaces/httpresponse.md).[headers](../interfaces/httpresponse.md#headers)*
+
+Defined in src/core/http-response/http-response-impl.ts:9
+
+___
+
+### `Readonly` status
+
+• **status**: *[HttpStatus](../enums/httpstatus.md)*
+
+*Implementation of [HttpResponse](../interfaces/httpresponse.md).[status](../interfaces/httpresponse.md#status)*
+
+Defined in src/core/http-response/http-response-impl.ts:7
+
+## Methods
+
+###  addHeader
+
+▸ **addHeader**(`header`: keyof ResponseHttpHeaders, `value`: string | string[]): *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+Defined in src/core/http-response/http-response-impl.ts:16
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof ResponseHttpHeaders |
+`value` | string &#124; string[] |
+
+**Returns:** *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+___
+
+###  removeHeader
+
+▸ **removeHeader**(`headerToRemove`: keyof ResponseHttpHeaders): *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+Defined in src/core/http-response/http-response-impl.ts:38
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`headerToRemove` | keyof ResponseHttpHeaders |
+
+**Returns:** *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+___
+
+###  replaceHeader
+
+▸ **replaceHeader**(`header`: keyof ResponseHttpHeaders, `value`: string | string[]): *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+Defined in src/core/http-response/http-response-impl.ts:27
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof ResponseHttpHeaders |
+`value` | string &#124; string[] |
+
+**Returns:** *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+___
+
+###  setBody
+
+▸ **setBody**(`body`: [HttpBody](../interfaces/httpbody.md) | string): *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+Defined in src/core/http-response/http-response-impl.ts:54
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`body` | [HttpBody](../interfaces/httpbody.md) &#124; string |
+
+**Returns:** *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+___
+
+###  setHeaders
+
+▸ **setHeaders**(`headers`: [ResponseHttpHeaders](../interfaces/responsehttpheaders.md)): *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+Defined in src/core/http-response/http-response-impl.ts:12
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`headers` | [ResponseHttpHeaders](../interfaces/responsehttpheaders.md) |
+
+**Returns:** *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+___
+
+###  setStatus
+
+▸ **setStatus**(`status`: [HttpStatus](../enums/httpstatus.md)): *[HttpResponseImpl](httpresponseimpl.md)‹›*
+
+Defined in src/core/http-response/http-response-impl.ts:60
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`status` | [HttpStatus](../enums/httpstatus.md) |
+
+**Returns:** *[HttpResponseImpl](httpresponseimpl.md)‹›*

--- a/website/docs/api/classes/stringbody.md
+++ b/website/docs/api/classes/stringbody.md
@@ -1,0 +1,64 @@
+---
+id: "stringbody"
+title: "StringBody"
+sidebar_label: "StringBody"
+---
+
+[http4ts - v0.0.3](../index.md) › [StringBody](stringbody.md)
+
+## Hierarchy
+
+* **StringBody**
+
+## Implements
+
+* [HttpBody](../interfaces/httpbody.md)
+
+## Index
+
+### Constructors
+
+* [constructor](stringbody.md#constructor)
+
+### Methods
+
+* [[Symbol.asyncIterator]](stringbody.md#[symbol.asynciterator])
+* [asString](stringbody.md#asstring)
+
+## Constructors
+
+###  constructor
+
+\+ **new StringBody**(`content`: string): *[StringBody](stringbody.md)*
+
+Defined in src/core/http-body/string-body.ts:4
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`content` | string |
+
+**Returns:** *[StringBody](stringbody.md)*
+
+## Methods
+
+###  [Symbol.asyncIterator]
+
+▸ **[Symbol.asyncIterator]**(): *AsyncGenerator‹Uint8Array‹›, void, unknown›*
+
+*Implementation of [HttpBody](../interfaces/httpbody.md)*
+
+Defined in src/core/http-body/string-body.ts:11
+
+**Returns:** *AsyncGenerator‹Uint8Array‹›, void, unknown›*
+
+___
+
+###  asString
+
+▸ **asString**(): *Promise‹string›*
+
+Defined in src/core/http-body/string-body.ts:7
+
+**Returns:** *Promise‹string›*

--- a/website/docs/api/enums/httpmethods.md
+++ b/website/docs/api/enums/httpmethods.md
@@ -1,0 +1,93 @@
+---
+id: "httpmethods"
+title: "HttpMethods"
+sidebar_label: "HttpMethods"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpMethods](httpmethods.md)
+
+## Index
+
+### Enumeration members
+
+* [DELETE](httpmethods.md#delete)
+* [GET](httpmethods.md#get)
+* [HEAD](httpmethods.md#head)
+* [OPTIONS](httpmethods.md#options)
+* [PATCH](httpmethods.md#patch)
+* [POST](httpmethods.md#post)
+* [PURGE](httpmethods.md#purge)
+* [PUT](httpmethods.md#put)
+* [TRACE](httpmethods.md#trace)
+
+## Enumeration members
+
+###  DELETE
+
+• **DELETE**: = "DELETE"
+
+Defined in src/core/http.ts:15
+
+___
+
+###  GET
+
+• **GET**: = "GET"
+
+Defined in src/core/http.ts:12
+
+___
+
+###  HEAD
+
+• **HEAD**: = "HEAD"
+
+Defined in src/core/http.ts:20
+
+___
+
+###  OPTIONS
+
+• **OPTIONS**: = "OPTIONS"
+
+Defined in src/core/http.ts:16
+
+___
+
+###  PATCH
+
+• **PATCH**: = "PATCH"
+
+Defined in src/core/http.ts:18
+
+___
+
+###  POST
+
+• **POST**: = "POST"
+
+Defined in src/core/http.ts:13
+
+___
+
+###  PURGE
+
+• **PURGE**: = "PURGE"
+
+Defined in src/core/http.ts:19
+
+___
+
+###  PUT
+
+• **PUT**: = "PUT"
+
+Defined in src/core/http.ts:14
+
+___
+
+###  TRACE
+
+• **TRACE**: = "TRACE"
+
+Defined in src/core/http.ts:17

--- a/website/docs/api/enums/httpstatus.md
+++ b/website/docs/api/enums/httpstatus.md
@@ -1,0 +1,715 @@
+---
+id: "httpstatus"
+title: "HttpStatus"
+sidebar_label: "HttpStatus"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpStatus](httpstatus.md)
+
+## Index
+
+### Enumeration members
+
+* [ACCEPTED](httpstatus.md#accepted)
+* [BAD_GATEWAY](httpstatus.md#bad_gateway)
+* [BAD_REQUEST](httpstatus.md#bad_request)
+* [CONFLICT](httpstatus.md#conflict)
+* [CONTINUE](httpstatus.md#continue)
+* [CREATED](httpstatus.md#created)
+* [EXPECTATION_FAILED](httpstatus.md#expectation_failed)
+* [FAILED_DEPENDENCY](httpstatus.md#failed_dependency)
+* [FORBIDDEN](httpstatus.md#forbidden)
+* [GATEWAY_TIMEOUT](httpstatus.md#gateway_timeout)
+* [GONE](httpstatus.md#gone)
+* [HTTP_VERSION_NOT_SUPPORTED](httpstatus.md#http_version_not_supported)
+* [IM_A_TEAPOT](httpstatus.md#im_a_teapot)
+* [INSUFFICIENT_SPACE_ON_RESOURCE](httpstatus.md#insufficient_space_on_resource)
+* [INSUFFICIENT_STORAGE](httpstatus.md#insufficient_storage)
+* [INTERNAL_SERVER_ERROR](httpstatus.md#internal_server_error)
+* [LENGTH_REQUIRED](httpstatus.md#length_required)
+* [LOCKED](httpstatus.md#locked)
+* [METHOD_FAILURE](httpstatus.md#method_failure)
+* [METHOD_NOT_ALLOWED](httpstatus.md#method_not_allowed)
+* [MOVED_PERMANENTLY](httpstatus.md#moved_permanently)
+* [MOVED_TEMPORARILY](httpstatus.md#moved_temporarily)
+* [MULTIPLE_CHOICES](httpstatus.md#multiple_choices)
+* [MULTI_STATUS](httpstatus.md#multi_status)
+* [NETWORK_AUTHENTICATION_REQUIRED](httpstatus.md#network_authentication_required)
+* [NON_AUTHORITATIVE_INFORMATION](httpstatus.md#non_authoritative_information)
+* [NOT_ACCEPTABLE](httpstatus.md#not_acceptable)
+* [NOT_FOUND](httpstatus.md#not_found)
+* [NOT_IMPLEMENTED](httpstatus.md#not_implemented)
+* [NOT_MODIFIED](httpstatus.md#not_modified)
+* [NO_CONTENT](httpstatus.md#no_content)
+* [OK](httpstatus.md#ok)
+* [PARTIAL_CONTENT](httpstatus.md#partial_content)
+* [PAYMENT_REQUIRED](httpstatus.md#payment_required)
+* [PERMANENT_REDIRECT](httpstatus.md#permanent_redirect)
+* [PRECONDITION_FAILED](httpstatus.md#precondition_failed)
+* [PRECONDITION_REQUIRED](httpstatus.md#precondition_required)
+* [PROCESSING](httpstatus.md#processing)
+* [PROXY_AUTHENTICATION_REQUIRED](httpstatus.md#proxy_authentication_required)
+* [REQUESTED_RANGE_NOT_SATISFIABLE](httpstatus.md#requested_range_not_satisfiable)
+* [REQUEST_HEADER_FIELDS_TOO_LARGE](httpstatus.md#request_header_fields_too_large)
+* [REQUEST_TIMEOUT](httpstatus.md#request_timeout)
+* [REQUEST_TOO_LONG](httpstatus.md#request_too_long)
+* [REQUEST_URI_TOO_LONG](httpstatus.md#request_uri_too_long)
+* [RESET_CONTENT](httpstatus.md#reset_content)
+* [SEE_OTHER](httpstatus.md#see_other)
+* [SERVICE_UNAVAILABLE](httpstatus.md#service_unavailable)
+* [SWITCHING_PROTOCOLS](httpstatus.md#switching_protocols)
+* [TEMPORARY_REDIRECT](httpstatus.md#temporary_redirect)
+* [TOO_MANY_REQUESTS](httpstatus.md#too_many_requests)
+* [UNAUTHORIZED](httpstatus.md#unauthorized)
+* [UNPROCESSABLE_ENTITY](httpstatus.md#unprocessable_entity)
+* [UNSUPPORTED_MEDIA_TYPE](httpstatus.md#unsupported_media_type)
+* [USE_PROXY](httpstatus.md#use_proxy)
+
+## Enumeration members
+
+###  ACCEPTED
+
+• **ACCEPTED**: = 202
+
+Defined in src/core/http-status.ts:7
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.3.3
+
+The request has been received but not yet acted upon. It is non-committal, meaning that there is no way in HTTP to later send an asynchronous response indicating the outcome of processing the request. It is intended for cases where another process or server handles the request, or for batch processing.
+
+___
+
+###  BAD_GATEWAY
+
+• **BAD_GATEWAY**: = 502
+
+Defined in src/core/http-status.ts:13
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.6.3
+
+This error response means that the server, while working as a gateway to get a response needed to handle the request, got an invalid response.
+
+___
+
+###  BAD_REQUEST
+
+• **BAD_REQUEST**: = 400
+
+Defined in src/core/http-status.ts:19
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.1
+
+This response means that server could not understand the request due to invalid syntax.
+
+___
+
+###  CONFLICT
+
+• **CONFLICT**: = 409
+
+Defined in src/core/http-status.ts:25
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.8
+
+This response is sent when a request conflicts with the current state of the server.
+
+___
+
+###  CONTINUE
+
+• **CONTINUE**: = 100
+
+Defined in src/core/http-status.ts:31
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.2.1
+
+This interim response indicates that everything so far is OK and that the client should continue with the request or ignore it if it is already finished.
+
+___
+
+###  CREATED
+
+• **CREATED**: = 201
+
+Defined in src/core/http-status.ts:37
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.3.2
+
+The request has succeeded and a new resource has been created as a result of it. This is typically the response sent after a PUT request.
+
+___
+
+###  EXPECTATION_FAILED
+
+• **EXPECTATION_FAILED**: = 417
+
+Defined in src/core/http-status.ts:43
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.14
+
+This response code means the expectation indicated by the Expect request header field can't be met by the server.
+
+___
+
+###  FAILED_DEPENDENCY
+
+• **FAILED_DEPENDENCY**: = 424
+
+Defined in src/core/http-status.ts:49
+
+Official Documentation @ https://tools.ietf.org/html/rfc2518#section-10.5
+
+The request failed due to failure of a previous request.
+
+___
+
+###  FORBIDDEN
+
+• **FORBIDDEN**: = 403
+
+Defined in src/core/http-status.ts:55
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.3
+
+The client does not have access rights to the content, i.e. they are unauthorized, so server is rejecting to give proper response. Unlike 401, the client's identity is known to the server.
+
+___
+
+###  GATEWAY_TIMEOUT
+
+• **GATEWAY_TIMEOUT**: = 504
+
+Defined in src/core/http-status.ts:61
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.6.5
+
+This error response is given when the server is acting as a gateway and cannot get a response in time.
+
+___
+
+###  GONE
+
+• **GONE**: = 410
+
+Defined in src/core/http-status.ts:67
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.9
+
+This response would be sent when the requested content has been permenantly deleted from server, with no forwarding address. Clients are expected to remove their caches and links to the resource. The HTTP specification intends this status code to be used for "limited-time, promotional services". APIs should not feel compelled to indicate resources that have been deleted with this status code.
+
+___
+
+###  HTTP_VERSION_NOT_SUPPORTED
+
+• **HTTP_VERSION_NOT_SUPPORTED**: = 505
+
+Defined in src/core/http-status.ts:73
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.6.6
+
+The HTTP version used in the request is not supported by the server.
+
+___
+
+###  IM_A_TEAPOT
+
+• **IM_A_TEAPOT**: = 418
+
+Defined in src/core/http-status.ts:79
+
+Official Documentation @ https://tools.ietf.org/html/rfc2324#section-2.3.2
+
+Any attempt to brew coffee with a teapot should result in the error code "418 I'm a teapot". The resulting entity body MAY be short and stout.
+
+___
+
+###  INSUFFICIENT_SPACE_ON_RESOURCE
+
+• **INSUFFICIENT_SPACE_ON_RESOURCE**: = 419
+
+Defined in src/core/http-status.ts:83
+
+UNOFFICIAL w/ NO DOCS
+
+___
+
+###  INSUFFICIENT_STORAGE
+
+• **INSUFFICIENT_STORAGE**: = 507
+
+Defined in src/core/http-status.ts:89
+
+Official Documentation @ https://tools.ietf.org/html/rfc2518#section-10.6
+
+The server has an internal configuration error: the chosen variant resource is configured to engage in transparent content negotiation itself, and is therefore not a proper end point in the negotiation process.
+
+___
+
+###  INTERNAL_SERVER_ERROR
+
+• **INTERNAL_SERVER_ERROR**: = 500
+
+Defined in src/core/http-status.ts:95
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.6.1
+
+The server has encountered a situation it doesn't know how to handle.
+
+___
+
+###  LENGTH_REQUIRED
+
+• **LENGTH_REQUIRED**: = 411
+
+Defined in src/core/http-status.ts:101
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.10
+
+Server rejected the request because the Content-Length header field is not defined and the server requires it.
+
+___
+
+###  LOCKED
+
+• **LOCKED**: = 423
+
+Defined in src/core/http-status.ts:107
+
+Official Documentation @ https://tools.ietf.org/html/rfc2518#section-10.4
+
+The resource that is being accessed is locked.
+
+___
+
+###  METHOD_FAILURE
+
+• **METHOD_FAILURE**: = 420
+
+Defined in src/core/http-status.ts:112
+
+**`deprecated`** 
+A deprecated response used by the Spring Framework when a method has failed.
+
+___
+
+###  METHOD_NOT_ALLOWED
+
+• **METHOD_NOT_ALLOWED**: = 405
+
+Defined in src/core/http-status.ts:118
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.5
+
+The request method is known by the server but has been disabled and cannot be used. For example, an API may forbid DELETE-ing a resource. The two mandatory methods, GET and HEAD, must never be disabled and should not return this error code.
+
+___
+
+###  MOVED_PERMANENTLY
+
+• **MOVED_PERMANENTLY**: = 301
+
+Defined in src/core/http-status.ts:124
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.4.2
+
+This response code means that URI of requested resource has been changed. Probably, new URI would be given in the response.
+
+___
+
+###  MOVED_TEMPORARILY
+
+• **MOVED_TEMPORARILY**: = 302
+
+Defined in src/core/http-status.ts:130
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.4.3
+
+This response code means that URI of requested resource has been changed temporarily. New changes in the URI might be made in the future. Therefore, this same URI should be used by the client in future requests.
+
+___
+
+###  MULTIPLE_CHOICES
+
+• **MULTIPLE_CHOICES**: = 300
+
+Defined in src/core/http-status.ts:142
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.4.1
+
+The request has more than one possible responses. User-agent or user should choose one of them. There is no standardized way to choose one of the responses.
+
+___
+
+###  MULTI_STATUS
+
+• **MULTI_STATUS**: = 207
+
+Defined in src/core/http-status.ts:136
+
+Official Documentation @ https://tools.ietf.org/html/rfc2518#section-10.2
+
+A Multi-Status response conveys information about multiple resources in situations where multiple status codes might be appropriate.
+
+___
+
+###  NETWORK_AUTHENTICATION_REQUIRED
+
+• **NETWORK_AUTHENTICATION_REQUIRED**: = 511
+
+Defined in src/core/http-status.ts:148
+
+Official Documentation @ https://tools.ietf.org/html/rfc6585#section-6
+
+The 511 status code indicates that the client needs to authenticate to gain network access.
+
+___
+
+###  NON_AUTHORITATIVE_INFORMATION
+
+• **NON_AUTHORITATIVE_INFORMATION**: = 203
+
+Defined in src/core/http-status.ts:159
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.3.4
+This response code means returned meta-information set is not exact set as available from the origin server, but collected from a local or a third party copy. Except this condition, 200 OK response should be preferred instead of this response.
+
+___
+
+###  NOT_ACCEPTABLE
+
+• **NOT_ACCEPTABLE**: = 406
+
+Defined in src/core/http-status.ts:165
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.6
+
+This response is sent when the web server, after performing server-driven content negotiation, doesn't find any content following the criteria given by the user agent.
+
+___
+
+###  NOT_FOUND
+
+• **NOT_FOUND**: = 404
+
+Defined in src/core/http-status.ts:171
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.4
+
+The server can not find requested resource. In the browser, this means the URL is not recognized. In an API, this can also mean that the endpoint is valid but the resource itself does not exist. Servers may also send this response instead of 403 to hide the existence of a resource from an unauthorized client. This response code is probably the most famous one due to its frequent occurence on the web.
+
+___
+
+###  NOT_IMPLEMENTED
+
+• **NOT_IMPLEMENTED**: = 501
+
+Defined in src/core/http-status.ts:177
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.6.2
+
+The request method is not supported by the server and cannot be handled. The only methods that servers are required to support (and therefore that must not return this code) are GET and HEAD.
+
+___
+
+###  NOT_MODIFIED
+
+• **NOT_MODIFIED**: = 304
+
+Defined in src/core/http-status.ts:183
+
+Official Documentation @ https://tools.ietf.org/html/rfc7232#section-4.1
+
+This is used for caching purposes. It is telling to client that response has not been modified. So, client can continue to use same cached version of response.
+
+___
+
+###  NO_CONTENT
+
+• **NO_CONTENT**: = 204
+
+Defined in src/core/http-status.ts:154
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.3.5
+
+There is no content to send for this request, but the headers may be useful. The user-agent may update its cached headers for this resource with the new ones.
+
+___
+
+###  OK
+
+• **OK**: = 200
+
+Defined in src/core/http-status.ts:193
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.3.1
+
+The request has succeeded. The meaning of a success varies depending on the HTTP method:
+GET: The resource has been fetched and is transmitted in the message body.
+HEAD: The entity headers are in the message body.
+POST: The resource describing the result of the action is transmitted in the message body.
+TRACE: The message body contains the request message as received by the server
+
+___
+
+###  PARTIAL_CONTENT
+
+• **PARTIAL_CONTENT**: = 206
+
+Defined in src/core/http-status.ts:199
+
+Official Documentation @ https://tools.ietf.org/html/rfc7233#section-4.1
+
+This response code is used because of range header sent by the client to separate download into multiple streams.
+
+___
+
+###  PAYMENT_REQUIRED
+
+• **PAYMENT_REQUIRED**: = 402
+
+Defined in src/core/http-status.ts:205
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.2
+
+This response code is reserved for future use. Initial aim for creating this code was using it for digital payment systems however this is not used currently.
+
+___
+
+###  PERMANENT_REDIRECT
+
+• **PERMANENT_REDIRECT**: = 308
+
+Defined in src/core/http-status.ts:211
+
+Official Documentation @ https://tools.ietf.org/html/rfc7538#section-3
+
+This means that the resource is now permanently located at another URI, specified by the Location: HTTP Response header. This has the same semantics as the 301 Moved Permanently HTTP response code, with the exception that the user agent must not change the HTTP method used: if a POST was used in the first request, a POST must be used in the second request.
+
+___
+
+###  PRECONDITION_FAILED
+
+• **PRECONDITION_FAILED**: = 412
+
+Defined in src/core/http-status.ts:217
+
+Official Documentation @ https://tools.ietf.org/html/rfc7232#section-4.2
+
+The client has indicated preconditions in its headers which the server does not meet.
+
+___
+
+###  PRECONDITION_REQUIRED
+
+• **PRECONDITION_REQUIRED**: = 428
+
+Defined in src/core/http-status.ts:223
+
+Official Documentation @ https://tools.ietf.org/html/rfc6585#section-3
+
+The origin server requires the request to be conditional. Intended to prevent the 'lost update' problem, where a client GETs a resource's state, modifies it, and PUTs it back to the server, when meanwhile a third party has modified the state on the server, leading to a conflict.
+
+___
+
+###  PROCESSING
+
+• **PROCESSING**: = 102
+
+Defined in src/core/http-status.ts:229
+
+Official Documentation @ https://tools.ietf.org/html/rfc2518#section-10.1
+
+This code indicates that the server has received and is processing the request, but no response is available yet.
+
+___
+
+###  PROXY_AUTHENTICATION_REQUIRED
+
+• **PROXY_AUTHENTICATION_REQUIRED**: = 407
+
+Defined in src/core/http-status.ts:235
+
+Official Documentation @ https://tools.ietf.org/html/rfc7235#section-3.2
+
+This is similar to 401 but authentication is needed to be done by a proxy.
+
+___
+
+###  REQUESTED_RANGE_NOT_SATISFIABLE
+
+• **REQUESTED_RANGE_NOT_SATISFIABLE**: = 416
+
+Defined in src/core/http-status.ts:265
+
+Official Documentation @ https://tools.ietf.org/html/rfc7233#section-4.4
+
+The range specified by the Range header field in the request can't be fulfilled, it's possible that the range is outside the size of the target URI's data.
+
+___
+
+###  REQUEST_HEADER_FIELDS_TOO_LARGE
+
+• **REQUEST_HEADER_FIELDS_TOO_LARGE**: = 431
+
+Defined in src/core/http-status.ts:241
+
+Official Documentation @ https://tools.ietf.org/html/rfc6585#section-5
+
+The server is unwilling to process the request because its header fields are too large. The request MAY be resubmitted after reducing the size of the request header fields.
+
+___
+
+###  REQUEST_TIMEOUT
+
+• **REQUEST_TIMEOUT**: = 408
+
+Defined in src/core/http-status.ts:247
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.7
+
+This response is sent on an idle connection by some servers, even without any previous request by the client. It means that the server would like to shut down this unused connection. This response is used much more since some browsers, like Chrome, Firefox 27+, or IE9, use HTTP pre-connection mechanisms to speed up surfing. Also note that some servers merely shut down the connection without sending this message.
+
+___
+
+###  REQUEST_TOO_LONG
+
+• **REQUEST_TOO_LONG**: = 413
+
+Defined in src/core/http-status.ts:253
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.11
+
+Request entity is larger than limits defined by server, the server might close the connection or return an Retry-After header field.
+
+___
+
+###  REQUEST_URI_TOO_LONG
+
+• **REQUEST_URI_TOO_LONG**: = 414
+
+Defined in src/core/http-status.ts:259
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.12
+
+The URI requested by the client is longer than the server is willing to interpret.
+
+___
+
+###  RESET_CONTENT
+
+• **RESET_CONTENT**: = 205
+
+Defined in src/core/http-status.ts:271
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.3.6
+
+This response code is sent after accomplishing request to tell user agent reset document view which sent this request.
+
+___
+
+###  SEE_OTHER
+
+• **SEE_OTHER**: = 303
+
+Defined in src/core/http-status.ts:277
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.4.4
+
+Server sent this response to directing client to get requested resource to another URI with an GET request.
+
+___
+
+###  SERVICE_UNAVAILABLE
+
+• **SERVICE_UNAVAILABLE**: = 503
+
+Defined in src/core/http-status.ts:283
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.6.4
+
+The server is not ready to handle the request. Common causes are a server that is down for maintenance or that is overloaded. Note that together with this response, a user-friendly page explaining the problem should be sent. This responses should be used for temporary conditions and the Retry-After: HTTP header should, if possible, contain the estimated time before the recovery of the service. The webmaster must also take care about the caching-related headers that are sent along with this response, as these temporary condition responses should usually not be cached.
+
+___
+
+###  SWITCHING_PROTOCOLS
+
+• **SWITCHING_PROTOCOLS**: = 101
+
+Defined in src/core/http-status.ts:289
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.2.2
+
+This code is sent in response to an Upgrade request header by the client, and indicates the protocol the server is switching too.
+
+___
+
+###  TEMPORARY_REDIRECT
+
+• **TEMPORARY_REDIRECT**: = 307
+
+Defined in src/core/http-status.ts:295
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.4.7
+
+Server sent this response to directing client to get requested resource to another URI with same method that used prior request. This has the same semantic than the 302 Found HTTP response code, with the exception that the user agent must not change the HTTP method used: if a POST was used in the first request, a POST must be used in the second request.
+
+___
+
+###  TOO_MANY_REQUESTS
+
+• **TOO_MANY_REQUESTS**: = 429
+
+Defined in src/core/http-status.ts:301
+
+Official Documentation @ https://tools.ietf.org/html/rfc6585#section-4
+
+The user has sent too many requests in a given amount of time ("rate limiting").
+
+___
+
+###  UNAUTHORIZED
+
+• **UNAUTHORIZED**: = 401
+
+Defined in src/core/http-status.ts:307
+
+Official Documentation @ https://tools.ietf.org/html/rfc7235#section-3.1
+
+Although the HTTP standard specifies "unauthorized", semantically this response means "unauthenticated". That is, the client must authenticate itself to get the requested response.
+
+___
+
+###  UNPROCESSABLE_ENTITY
+
+• **UNPROCESSABLE_ENTITY**: = 422
+
+Defined in src/core/http-status.ts:313
+
+Official Documentation @ https://tools.ietf.org/html/rfc2518#section-10.3
+
+The request was well-formed but was unable to be followed due to semantic errors.
+
+___
+
+###  UNSUPPORTED_MEDIA_TYPE
+
+• **UNSUPPORTED_MEDIA_TYPE**: = 415
+
+Defined in src/core/http-status.ts:319
+
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.5.13
+
+The media format of the requested data is not supported by the server, so the server is rejecting the request.
+
+___
+
+###  USE_PROXY
+
+• **USE_PROXY**: = 305
+
+Defined in src/core/http-status.ts:326
+
+**`deprecated`** 
+Official Documentation @ https://tools.ietf.org/html/rfc7231#section-6.4.6
+
+Was defined in a previous version of the HTTP specification to indicate that a requested response must be accessed by a proxy. It has been deprecated due to security concerns regarding in-band configuration of a proxy.

--- a/website/docs/api/index.md
+++ b/website/docs/api/index.md
@@ -1,0 +1,851 @@
+---
+id: "index"
+title: "http4ts - v0.0.3"
+sidebar_label: "Globals"
+---
+
+[http4ts - v0.0.3](index.md)
+
+## Index
+
+### Enumerations
+
+* [HttpMethods](enums/httpmethods.md)
+* [HttpStatus](enums/httpstatus.md)
+
+### Classes
+
+* [BufferedBody](classes/bufferedbody.md)
+* [HttpRequestImpl](classes/httprequestimpl.md)
+* [HttpResponseImpl](classes/httpresponseimpl.md)
+* [StringBody](classes/stringbody.md)
+
+### Interfaces
+
+* [HttpBody](interfaces/httpbody.md)
+* [HttpHeaders](interfaces/httpheaders.md)
+* [HttpMessage](interfaces/httpmessage.md)
+* [HttpRequest](interfaces/httprequest.md)
+* [HttpResponse](interfaces/httpresponse.md)
+* [Key](interfaces/key.md)
+* [LexToken](interfaces/lextoken.md)
+* [MatchResult](interfaces/matchresult.md)
+* [ParseOptions](interfaces/parseoptions.md)
+* [RegexpToFunctionOptions](interfaces/regexptofunctionoptions.md)
+* [RequestHttpHeaders](interfaces/requesthttpheaders.md)
+* [ResponseHttpHeaders](interfaces/responsehttpheaders.md)
+* [RouteDefinition](interfaces/routedefinition.md)
+* [RoutedHttpRequest](interfaces/routedhttprequest.md)
+* [TokensToFunctionOptions](interfaces/tokenstofunctionoptions.md)
+* [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md)
+* [URI](interfaces/uri.md)
+
+### Type aliases
+
+* [HttpFilter](index.md#httpfilter)
+* [HttpHandler](index.md#httphandler)
+* [HttpMethod](index.md#httpmethod)
+* [HttpQuery](index.md#httpquery)
+* [Match](index.md#match)
+* [MatchFunction](index.md#matchfunction)
+* [Path](index.md#path)
+* [PathFunction](index.md#pathfunction)
+* [RequestParams](index.md#requestparams)
+* [ResponeParams](index.md#responeparams)
+* [RoutedHttpHandler](index.md#routedhttphandler)
+* [Token](index.md#token)
+* [UriTemplate](index.md#uritemplate)
+
+### Variables
+
+* [TheTextDecoder](index.md#let-thetextdecoder)
+* [TheTextEncoder](index.md#let-thetextencoder)
+
+### Functions
+
+* [all](index.md#all)
+* [arrayToRegexp](index.md#arraytoregexp)
+* [asJson](index.md#asjson)
+* [compile](index.md#compile)
+* [defaultNotFoundHandler](index.md#defaultnotfoundhandler)
+* [escapeString](index.md#escapestring)
+* [flags](index.md#flags)
+* [get](index.md#get)
+* [iterableToString](index.md#iterabletostring)
+* [jsonBody](index.md#jsonbody)
+* [lexer](index.md#lexer)
+* [match](index.md#match)
+* [notFound](index.md#notfound)
+* [parse](index.md#parse)
+* [pathToRegexp](index.md#pathtoregexp)
+* [post](index.md#post)
+* [regexpToFunction](index.md#regexptofunction)
+* [regexpToRegexp](index.md#regexptoregexp)
+* [req](index.md#req)
+* [res](index.md#res)
+* [route](index.md#route)
+* [routes](index.md#routes)
+* [setupEnvironment](index.md#setupenvironment)
+* [stringBody](index.md#stringbody)
+* [stringToIterable](index.md#stringtoiterable)
+* [stringToRegexp](index.md#stringtoregexp)
+* [tokensToFunction](index.md#tokenstofunction)
+* [tokensToRegexp](index.md#tokenstoregexp)
+
+## Type aliases
+
+###  HttpFilter
+
+Ƭ **HttpFilter**: *function*
+
+Defined in src/core/http4ts.ts:7
+
+#### Type declaration:
+
+▸ (`handler`: [HttpHandler](index.md#httphandler)): *Promise‹[HttpHandler](index.md#httphandler)› | [HttpHandler](index.md#httphandler)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [HttpHandler](index.md#httphandler) |
+
+___
+
+###  HttpHandler
+
+Ƭ **HttpHandler**: *function*
+
+Defined in src/core/http4ts.ts:3
+
+#### Type declaration:
+
+▸ (`req`: [HttpRequest](interfaces/httprequest.md)): *[HttpResponse](interfaces/httpresponse.md) | Promise‹[HttpResponse](interfaces/httpresponse.md)›*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`req` | [HttpRequest](interfaces/httprequest.md) |
+
+___
+
+###  HttpMethod
+
+Ƭ **HttpMethod**: *[HttpMethods](enums/httpmethods.md) | string*
+
+Defined in src/core/http.ts:23
+
+___
+
+###  HttpQuery
+
+Ƭ **HttpQuery**: *string | string[] | undefined | null*
+
+Defined in src/core/http.ts:9
+
+___
+
+###  Match
+
+Ƭ **Match**: *false | [MatchResult](interfaces/matchresult.md)‹P›*
+
+Defined in src/core/routing/path-to-regexp.ts:365
+
+A match is either `false` (no match) or a match result.
+
+___
+
+###  MatchFunction
+
+Ƭ **MatchFunction**: *function*
+
+Defined in src/core/routing/path-to-regexp.ts:370
+
+The match function takes a string and returns whether it matched the path.
+
+#### Type declaration:
+
+▸ (`path`: string): *[Match](index.md#match)‹P›*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+___
+
+###  Path
+
+Ƭ **Path**: *string | RegExp | Array‹string | RegExp›*
+
+Defined in src/core/routing/path-to-regexp.ts:602
+
+Supported `path-to-regexp` input types.
+
+___
+
+###  PathFunction
+
+Ƭ **PathFunction**: *function*
+
+Defined in src/core/routing/path-to-regexp.ts:261
+
+#### Type declaration:
+
+▸ (`data?`: P): *string*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`data?` | P |
+
+___
+
+###  RequestParams
+
+Ƭ **RequestParams**: *object*
+
+Defined in src/core/http-request/helpers.ts:6
+
+#### Type declaration:
+
+* **body**? : *[HttpBody](interfaces/httpbody.md) | string*
+
+* **headers**? : *[RequestHttpHeaders](interfaces/requesthttpheaders.md)*
+
+* **method**? : *[HttpMethod](index.md#httpmethod)*
+
+* **url**: *string*
+
+___
+
+###  ResponeParams
+
+Ƭ **ResponeParams**: *object*
+
+Defined in src/core/http-response/helpers.ts:7
+
+#### Type declaration:
+
+* **body**? : *[HttpBody](interfaces/httpbody.md) | string*
+
+* **headers**? : *[ResponseHttpHeaders](interfaces/responsehttpheaders.md)*
+
+* **status**: *[HttpStatus](enums/httpstatus.md)*
+
+___
+
+###  RoutedHttpHandler
+
+Ƭ **RoutedHttpHandler**: *function*
+
+Defined in src/core/routing/routes.ts:11
+
+#### Type declaration:
+
+▸ (`req`: [RoutedHttpRequest](interfaces/routedhttprequest.md)): *[HttpResponse](interfaces/httpresponse.md) | Promise‹[HttpResponse](interfaces/httpresponse.md)›*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`req` | [RoutedHttpRequest](interfaces/routedhttprequest.md) |
+
+___
+
+###  Token
+
+Ƭ **Token**: *string | [Key](interfaces/key.md)*
+
+Defined in src/core/routing/path-to-regexp.ts:450
+
+A token is a string (nothing special) or key metadata (capture group).
+
+___
+
+###  UriTemplate
+
+Ƭ **UriTemplate**: *string*
+
+Defined in src/core/routing/routes.ts:15
+
+## Variables
+
+### `Let` TheTextDecoder
+
+• **TheTextDecoder**: *typeof TextDecoder*
+
+Defined in src/core/env.ts:1
+
+___
+
+### `Let` TheTextEncoder
+
+• **TheTextEncoder**: *typeof TextEncoder*
+
+Defined in src/core/env.ts:2
+
+## Functions
+
+###  all
+
+▸ **all**(`path`: [UriTemplate](index.md#uritemplate), `handler`: [RoutedHttpHandler](index.md#routedhttphandler)): *[RouteDefinition](interfaces/routedefinition.md)*
+
+Defined in src/core/routing/routes.ts:106
+
+Defines a route for the specified uri template no matter what http method used for the request
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`path` | [UriTemplate](index.md#uritemplate) | Uri template to define the path for this route handler |
+`handler` | [RoutedHttpHandler](index.md#routedhttphandler) | HttpHandler to be called when the request matches this route  |
+
+**Returns:** *[RouteDefinition](interfaces/routedefinition.md)*
+
+___
+
+###  arrayToRegexp
+
+▸ **arrayToRegexp**(`paths`: Array‹string | RegExp›, `keys?`: [Key](interfaces/key.md)[], `options?`: [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) & [ParseOptions](interfaces/parseoptions.md)): *RegExp*
+
+Defined in src/core/routing/path-to-regexp.ts:479
+
+Transform an array into a regexp.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`paths` | Array‹string &#124; RegExp› |
+`keys?` | [Key](interfaces/key.md)[] |
+`options?` | [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) & [ParseOptions](interfaces/parseoptions.md) |
+
+**Returns:** *RegExp*
+
+___
+
+###  asJson
+
+▸ **asJson**<**T**>(`body`: [HttpBody](interfaces/httpbody.md)): *Promise‹T›*
+
+Defined in src/core/http-body/helpers.ts:8
+
+Deserializes the provided body and returns the parsed object.
+
+**Type parameters:**
+
+▪ **T**
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`body` | [HttpBody](interfaces/httpbody.md) | HttpBody to be deserialized  |
+
+**Returns:** *Promise‹T›*
+
+___
+
+###  compile
+
+▸ **compile**<**P**>(`str`: string, `options?`: [ParseOptions](interfaces/parseoptions.md) & [TokensToFunctionOptions](interfaces/tokenstofunctionoptions.md)): *function*
+
+Defined in src/core/routing/path-to-regexp.ts:254
+
+Compile a string to a template function for the path.
+
+**Type parameters:**
+
+▪ **P**: *object*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`str` | string |
+`options?` | [ParseOptions](interfaces/parseoptions.md) & [TokensToFunctionOptions](interfaces/tokenstofunctionoptions.md) |
+
+**Returns:** *function*
+
+▸ (`data?`: P): *string*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`data?` | P |
+
+___
+
+###  defaultNotFoundHandler
+
+▸ **defaultNotFoundHandler**(): *[HttpResponse](interfaces/httpresponse.md)*
+
+Defined in src/core/routing/routes.ts:24
+
+**Returns:** *[HttpResponse](interfaces/httpresponse.md)*
+
+___
+
+###  escapeString
+
+▸ **escapeString**(`str`: string): *string*
+
+Defined in src/core/routing/path-to-regexp.ts:425
+
+Escape a regular expression string.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`str` | string |
+
+**Returns:** *string*
+
+___
+
+###  flags
+
+▸ **flags**(`options?`: undefined | object): *"" | "i"*
+
+Defined in src/core/routing/path-to-regexp.ts:432
+
+Get the flags for a regexp from the options.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`options?` | undefined &#124; object |
+
+**Returns:** *"" | "i"*
+
+___
+
+###  get
+
+▸ **get**(`path`: [UriTemplate](index.md#uritemplate), `handler`: [RoutedHttpHandler](index.md#routedhttphandler)): *[RouteDefinition](interfaces/routedefinition.md)*
+
+Defined in src/core/routing/routes.ts:124
+
+Defines a route for a GET request
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`path` | [UriTemplate](index.md#uritemplate) | Uri template to define the path for this route handler |
+`handler` | [RoutedHttpHandler](index.md#routedhttphandler) | HttpHandler to be called when the request matches this route  |
+
+**Returns:** *[RouteDefinition](interfaces/routedefinition.md)*
+
+___
+
+###  iterableToString
+
+▸ **iterableToString**(`it`: AsyncIterable‹Uint8Array | string›, `encoding`: string): *Promise‹string›*
+
+Defined in src/core/http-body/string-encoding-utils.ts:8
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`it` | AsyncIterable‹Uint8Array &#124; string› | - |
+`encoding` | string | "utf8" |
+
+**Returns:** *Promise‹string›*
+
+___
+
+###  jsonBody
+
+▸ **jsonBody**(`obj`: any): *[StringBody](classes/stringbody.md)‹›*
+
+Defined in src/core/http-body/helpers.ts:18
+
+Creates an HttpBody with the JSON representation of the provided object
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`obj` | any | Object that should be serialized as JSON for body content  |
+
+**Returns:** *[StringBody](classes/stringbody.md)‹›*
+
+___
+
+###  lexer
+
+▸ **lexer**(`str`: string): *[LexToken](interfaces/lextoken.md)[]*
+
+Defined in src/core/routing/path-to-regexp.ts:23
+
+Tokenize input string.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`str` | string |
+
+**Returns:** *[LexToken](interfaces/lextoken.md)[]*
+
+___
+
+###  match
+
+▸ **match**<**P**>(`str`: [Path](index.md#path), `options?`: [ParseOptions](interfaces/parseoptions.md) & [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) & [RegexpToFunctionOptions](interfaces/regexptofunctionoptions.md)): *function*
+
+Defined in src/core/routing/path-to-regexp.ts:377
+
+Create path match function from `path-to-regexp` spec.
+
+**Type parameters:**
+
+▪ **P**: *object*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`str` | [Path](index.md#path) |
+`options?` | [ParseOptions](interfaces/parseoptions.md) & [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) & [RegexpToFunctionOptions](interfaces/regexptofunctionoptions.md) |
+
+**Returns:** *function*
+
+▸ (`path`: string): *[Match](index.md#match)‹P›*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+___
+
+###  notFound
+
+▸ **notFound**(`handler`: [RoutedHttpHandler](index.md#routedhttphandler)): *[RouteDefinition](interfaces/routedefinition.md)*
+
+Defined in src/core/routing/routes.ts:147
+
+Defines a fallback route when the request path does not match any routes
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`handler` | [RoutedHttpHandler](index.md#routedhttphandler) | HttpHandler to be called when the request matches this route  |
+
+**Returns:** *[RouteDefinition](interfaces/routedefinition.md)*
+
+___
+
+###  parse
+
+▸ **parse**(`str`: string, `options`: [ParseOptions](interfaces/parseoptions.md)): *[Token](index.md#token)[]*
+
+Defined in src/core/routing/path-to-regexp.ts:142
+
+Parse a string for the raw tokens.
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`str` | string | - |
+`options` | [ParseOptions](interfaces/parseoptions.md) | {} |
+
+**Returns:** *[Token](index.md#token)[]*
+
+___
+
+###  pathToRegexp
+
+▸ **pathToRegexp**(`path`: [Path](index.md#path), `keys?`: [Key](interfaces/key.md)[], `options?`: [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) & [ParseOptions](interfaces/parseoptions.md)): *RegExp‹›*
+
+Defined in src/core/routing/path-to-regexp.ts:611
+
+Normalize the given path string, returning a regular expression.
+
+An empty array can be passed in for the keys, which will hold the
+placeholder key descriptions. For example, using `/user/:id`, `keys` will
+contain `[{ name: 'id', delimiter: '/', optional: false, repeat: false }]`.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | [Path](index.md#path) |
+`keys?` | [Key](interfaces/key.md)[] |
+`options?` | [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) & [ParseOptions](interfaces/parseoptions.md) |
+
+**Returns:** *RegExp‹›*
+
+___
+
+###  post
+
+▸ **post**(`path`: [UriTemplate](index.md#uritemplate), `handler`: [RoutedHttpHandler](index.md#routedhttphandler)): *[RouteDefinition](interfaces/routedefinition.md)*
+
+Defined in src/core/routing/routes.ts:136
+
+Defines a route for a POST request
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`path` | [UriTemplate](index.md#uritemplate) | Uri template to define the path for this route handler |
+`handler` | [RoutedHttpHandler](index.md#routedhttphandler) | HttpHandler to be called when the request matches this route  |
+
+**Returns:** *[RouteDefinition](interfaces/routedefinition.md)*
+
+___
+
+###  regexpToFunction
+
+▸ **regexpToFunction**<**P**>(`re`: RegExp, `keys`: [Key](interfaces/key.md)[], `options`: [RegexpToFunctionOptions](interfaces/regexptofunctionoptions.md)): *[MatchFunction](index.md#matchfunction)‹P›*
+
+Defined in src/core/routing/path-to-regexp.ts:389
+
+Create a path match function from `path-to-regexp` output.
+
+**Type parameters:**
+
+▪ **P**: *object*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`re` | RegExp | - |
+`keys` | [Key](interfaces/key.md)[] | - |
+`options` | [RegexpToFunctionOptions](interfaces/regexptofunctionoptions.md) | {} |
+
+**Returns:** *[MatchFunction](index.md#matchfunction)‹P›*
+
+___
+
+###  regexpToRegexp
+
+▸ **regexpToRegexp**(`path`: RegExp, `keys?`: [Key](interfaces/key.md)[]): *RegExp*
+
+Defined in src/core/routing/path-to-regexp.ts:455
+
+Pull out keys from a regexp.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | RegExp |
+`keys?` | [Key](interfaces/key.md)[] |
+
+**Returns:** *RegExp*
+
+___
+
+###  req
+
+▸ **req**(`__namedParameters`: object): *[HttpRequestImpl](classes/httprequestimpl.md)‹›*
+
+Defined in src/core/http-request/helpers.ts:17
+
+Instantiates an HttpResponse based on the provided data
+
+**Parameters:**
+
+▪ **__namedParameters**: *object*
+
+Name | Type | Default |
+------ | ------ | ------ |
+`body` | string &#124; [HttpBody](interfaces/httpbody.md)‹› | stringBody("") |
+`headers` | [RequestHttpHeaders](interfaces/requesthttpheaders.md) | - |
+`method` | string | HttpMethods.GET |
+`url` | string | - |
+
+**Returns:** *[HttpRequestImpl](classes/httprequestimpl.md)‹›*
+
+___
+
+###  res
+
+▸ **res**(`__namedParameters`: object): *[HttpResponseImpl](classes/httpresponseimpl.md)‹›*
+
+Defined in src/core/http-response/helpers.ts:17
+
+Instantiates an HttpResponse object based on the provided status, body and headers
+
+**Parameters:**
+
+▪ **__namedParameters**: *object*
+
+Name | Type | Default |
+------ | ------ | ------ |
+`body` | string &#124; [HttpBody](interfaces/httpbody.md)‹› | stringBody("") |
+`headers` | [ResponseHttpHeaders](interfaces/responsehttpheaders.md) | - |
+`status` | [HttpStatus](enums/httpstatus.md) | - |
+
+**Returns:** *[HttpResponseImpl](classes/httpresponseimpl.md)‹›*
+
+___
+
+###  route
+
+▸ **route**(`method`: [HttpMethod](index.md#httpmethod), `path`: [UriTemplate](index.md#uritemplate), `handler`: [RoutedHttpHandler](index.md#routedhttphandler)): *[RouteDefinition](interfaces/routedefinition.md)*
+
+Defined in src/core/routing/routes.ts:86
+
+Defines a route for the provided request path and method
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`method` | [HttpMethod](index.md#httpmethod) | HttpMethod for the route to be matched |
+`path` | [UriTemplate](index.md#uritemplate) | Uri template to define the path for this route handler |
+`handler` | [RoutedHttpHandler](index.md#routedhttphandler) | HttpHandler to be called when the request matches this route  |
+
+**Returns:** *[RouteDefinition](interfaces/routedefinition.md)*
+
+___
+
+###  routes
+
+▸ **routes**(`firstRouteDefinition`: [RouteDefinition](interfaces/routedefinition.md), ...`otherRouteDefinitions`: [RouteDefinition](interfaces/routedefinition.md)[]): *[HttpHandler](index.md#httphandler)*
+
+Defined in src/core/routing/routes.ts:37
+
+Creates an HttpHandler based of the defined routes. You can use this function to define the application router.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`firstRouteDefinition` | [RouteDefinition](interfaces/routedefinition.md) | Use one of the route definition creators like `get`, `post`, `notFound`, `all` and `route` |
+`...otherRouteDefinitions` | [RouteDefinition](interfaces/routedefinition.md)[] | Use one of the route definition creators like `get`, `post`, `notFound`, `all` and `route`. This is the rest parameter; Can be added indefinitely.  |
+
+**Returns:** *[HttpHandler](index.md#httphandler)*
+
+___
+
+###  setupEnvironment
+
+▸ **setupEnvironment**(`theTextDecoder`: typeof TextDecoder, `theTextEncoder`: typeof TextEncoder): *void*
+
+Defined in src/core/env.ts:6
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`theTextDecoder` | typeof TextDecoder |
+`theTextEncoder` | typeof TextEncoder |
+
+**Returns:** *void*
+
+___
+
+###  stringBody
+
+▸ **stringBody**(`content`: string): *[StringBody](classes/stringbody.md)‹›*
+
+Defined in src/core/http-body/helpers.ts:27
+
+Creates an HttpBody with the provided content
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`content` | string | Content of the body  |
+
+**Returns:** *[StringBody](classes/stringbody.md)‹›*
+
+___
+
+###  stringToIterable
+
+▸ **stringToIterable**(`content`: string): *AsyncGenerator‹Uint8Array‹›, void, unknown›*
+
+Defined in src/core/http-body/string-encoding-utils.ts:3
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`content` | string |
+
+**Returns:** *AsyncGenerator‹Uint8Array‹›, void, unknown›*
+
+___
+
+###  stringToRegexp
+
+▸ **stringToRegexp**(`path`: string, `keys?`: [Key](interfaces/key.md)[], `options?`: [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) & [ParseOptions](interfaces/parseoptions.md)): *RegExp‹›*
+
+Defined in src/core/routing/path-to-regexp.ts:491
+
+Create a path regexp from string input.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+`keys?` | [Key](interfaces/key.md)[] |
+`options?` | [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) & [ParseOptions](interfaces/parseoptions.md) |
+
+**Returns:** *RegExp‹›*
+
+___
+
+###  tokensToFunction
+
+▸ **tokensToFunction**<**P**>(`tokens`: [Token](index.md#token)[], `options`: [TokensToFunctionOptions](interfaces/tokenstofunctionoptions.md)): *[PathFunction](index.md#pathfunction)‹P›*
+
+Defined in src/core/routing/path-to-regexp.ts:266
+
+Expose a method for transforming tokens into the path function.
+
+**Type parameters:**
+
+▪ **P**: *object*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`tokens` | [Token](index.md#token)[] | - |
+`options` | [TokensToFunctionOptions](interfaces/tokenstofunctionoptions.md) | {} |
+
+**Returns:** *[PathFunction](index.md#pathfunction)‹P›*
+
+___
+
+###  tokensToRegexp
+
+▸ **tokensToRegexp**(`tokens`: [Token](index.md#token)[], `keys?`: [Key](interfaces/key.md)[], `options`: [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md)): *RegExp‹›*
+
+Defined in src/core/routing/path-to-regexp.ts:533
+
+Expose a function for taking tokens and returning a RegExp.
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`tokens` | [Token](index.md#token)[] | - |
+`keys?` | [Key](interfaces/key.md)[] | - |
+`options` | [TokensToRegexpOptions](interfaces/tokenstoregexpoptions.md) | {} |
+
+**Returns:** *RegExp‹›*

--- a/website/docs/api/interfaces/httpbody.md
+++ b/website/docs/api/interfaces/httpbody.md
@@ -1,0 +1,62 @@
+---
+id: "httpbody"
+title: "HttpBody"
+sidebar_label: "HttpBody"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpBody](httpbody.md)
+
+## Hierarchy
+
+* AsyncIterable‹Uint8Array | string›
+
+  ↳ **HttpBody**
+
+## Implemented by
+
+* [BufferedBody](../classes/bufferedbody.md)
+* [StringBody](../classes/stringbody.md)
+
+## Index
+
+### Properties
+
+* [asString](httpbody.md#asstring)
+
+### Methods
+
+* [[Symbol.asyncIterator]](httpbody.md#[symbol.asynciterator])
+
+## Properties
+
+###  asString
+
+• **asString**: *function*
+
+Defined in src/core/http.ts:30
+
+Reads the body stream to end and decodes it as string.
+
+**`param`** 
+
+#### Type declaration:
+
+▸ (`encoding?`: undefined | string): *Promise‹string›*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`encoding?` | undefined &#124; string |
+
+## Methods
+
+###  [Symbol.asyncIterator]
+
+▸ **[Symbol.asyncIterator]**(): *AsyncIterator‹Uint8Array | string›*
+
+*Inherited from [HttpBody](httpbody.md).[[Symbol.asyncIterator]](httpbody.md#[symbol.asynciterator])*
+
+Defined in node_modules/typescript/lib/lib.es2018.asynciterable.d.ts:40
+
+**Returns:** *AsyncIterator‹Uint8Array | string›*

--- a/website/docs/api/interfaces/httpheaders.md
+++ b/website/docs/api/interfaces/httpheaders.md
@@ -1,0 +1,19 @@
+---
+id: "httpheaders"
+title: "HttpHeaders"
+sidebar_label: "HttpHeaders"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpHeaders](httpheaders.md)
+
+## Hierarchy
+
+* **HttpHeaders**
+
+  ↳ [RequestHttpHeaders](requesthttpheaders.md)
+
+  ↳ [ResponseHttpHeaders](responsehttpheaders.md)
+
+## Indexable
+
+* \[ **header**: *string*\]: string | string[] | undefined

--- a/website/docs/api/interfaces/httpmessage.md
+++ b/website/docs/api/interfaces/httpmessage.md
@@ -1,0 +1,38 @@
+---
+id: "httpmessage"
+title: "HttpMessage"
+sidebar_label: "HttpMessage"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpMessage](httpmessage.md)
+
+## Hierarchy
+
+* **HttpMessage**
+
+  ↳ [HttpRequest](httprequest.md)
+
+  ↳ [HttpResponse](httpresponse.md)
+
+## Index
+
+### Properties
+
+* [body](httpmessage.md#body)
+* [headers](httpmessage.md#headers)
+
+## Properties
+
+###  body
+
+• **body**: *[HttpBody](httpbody.md)*
+
+Defined in src/core/http.ts:35
+
+___
+
+###  headers
+
+• **headers**: *[HttpHeaders](httpheaders.md)*
+
+Defined in src/core/http.ts:34

--- a/website/docs/api/interfaces/httprequest.md
+++ b/website/docs/api/interfaces/httprequest.md
@@ -1,0 +1,290 @@
+---
+id: "httprequest"
+title: "HttpRequest"
+sidebar_label: "HttpRequest"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpRequest](httprequest.md)
+
+## Hierarchy
+
+* [HttpMessage](httpmessage.md)
+
+  ↳ **HttpRequest**
+
+  ↳ [RoutedHttpRequest](routedhttprequest.md)
+
+## Implemented by
+
+* [HttpRequestImpl](../classes/httprequestimpl.md)
+
+## Index
+
+### Properties
+
+* [addHeader](httprequest.md#addheader)
+* [addQuery](httprequest.md#addquery)
+* [body](httprequest.md#body)
+* [headers](httprequest.md#headers)
+* [method](httprequest.md#method)
+* [path](httprequest.md#path)
+* [query](httprequest.md#query)
+* [removeHeader](httprequest.md#removeheader)
+* [removeQuery](httprequest.md#removequery)
+* [replaceHeader](httprequest.md#replaceheader)
+* [replaceQuery](httprequest.md#replacequery)
+* [setBody](httprequest.md#setbody)
+* [setHeaders](httprequest.md#setheaders)
+* [setMethod](httprequest.md#setmethod)
+* [setUrl](httprequest.md#seturl)
+* [url](httprequest.md#url)
+
+## Properties
+
+###  addHeader
+
+• **addHeader**: *function*
+
+Defined in src/core/http.ts:44
+
+#### Type declaration:
+
+▸ (`header`: keyof RequestHttpHeaders, `value`: string | string[]): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof RequestHttpHeaders |
+`value` | string &#124; string[] |
+
+___
+
+###  addQuery
+
+• **addQuery**: *function*
+
+Defined in src/core/http.ts:57
+
+#### Type declaration:
+
+▸ (`name`: string, `value`: string | string[]): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | string &#124; string[] |
+
+___
+
+###  body
+
+• **body**: *[HttpBody](httpbody.md)*
+
+*Inherited from [HttpMessage](httpmessage.md).[body](httpmessage.md#body)*
+
+Defined in src/core/http.ts:35
+
+___
+
+###  headers
+
+• **headers**: *[RequestHttpHeaders](requesthttpheaders.md)*
+
+*Overrides [HttpMessage](httpmessage.md).[headers](httpmessage.md#headers)*
+
+Defined in src/core/http.ts:39
+
+___
+
+###  method
+
+• **method**: *[HttpMethod](../index.md#httpmethod)*
+
+Defined in src/core/http.ts:40
+
+___
+
+###  path
+
+• **path**: *function*
+
+Defined in src/core/http.ts:59
+
+#### Type declaration:
+
+▸ (): *string*
+
+___
+
+###  query
+
+• **query**: *function*
+
+Defined in src/core/http.ts:55
+
+#### Type declaration:
+
+▸ (`name`: string): *[HttpQuery](../index.md#httpquery)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+___
+
+###  removeHeader
+
+• **removeHeader**: *function*
+
+Defined in src/core/http.ts:52
+
+#### Type declaration:
+
+▸ (`header`: keyof RequestHttpHeaders): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof RequestHttpHeaders |
+
+___
+
+###  removeQuery
+
+• **removeQuery**: *function*
+
+Defined in src/core/http.ts:56
+
+#### Type declaration:
+
+▸ (`name`: string): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+___
+
+###  replaceHeader
+
+• **replaceHeader**: *function*
+
+Defined in src/core/http.ts:48
+
+#### Type declaration:
+
+▸ (`header`: keyof RequestHttpHeaders, `value`: string | string[]): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof RequestHttpHeaders |
+`value` | string &#124; string[] |
+
+___
+
+###  replaceQuery
+
+• **replaceQuery**: *function*
+
+Defined in src/core/http.ts:58
+
+#### Type declaration:
+
+▸ (`name`: string, `value`: string | string[]): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | string &#124; string[] |
+
+___
+
+###  setBody
+
+• **setBody**: *function*
+
+Defined in src/core/http.ts:61
+
+#### Type declaration:
+
+▸ (`body`: [HttpBody](httpbody.md) | string): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`body` | [HttpBody](httpbody.md) &#124; string |
+
+___
+
+###  setHeaders
+
+• **setHeaders**: *function*
+
+Defined in src/core/http.ts:43
+
+#### Type declaration:
+
+▸ (`headers`: [RequestHttpHeaders](requesthttpheaders.md)): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`headers` | [RequestHttpHeaders](requesthttpheaders.md) |
+
+___
+
+###  setMethod
+
+• **setMethod**: *function*
+
+Defined in src/core/http.ts:63
+
+#### Type declaration:
+
+▸ (`method`: [HttpMethod](../index.md#httpmethod)): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`method` | [HttpMethod](../index.md#httpmethod) |
+
+___
+
+###  setUrl
+
+• **setUrl**: *function*
+
+Defined in src/core/http.ts:54
+
+#### Type declaration:
+
+▸ (`url`: string): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`url` | string |
+
+___
+
+###  url
+
+• **url**: *string*
+
+Defined in src/core/http.ts:41

--- a/website/docs/api/interfaces/httpresponse.md
+++ b/website/docs/api/interfaces/httpresponse.md
@@ -1,0 +1,169 @@
+---
+id: "httpresponse"
+title: "HttpResponse"
+sidebar_label: "HttpResponse"
+---
+
+[http4ts - v0.0.3](../index.md) › [HttpResponse](httpresponse.md)
+
+## Hierarchy
+
+* [HttpMessage](httpmessage.md)
+
+  ↳ **HttpResponse**
+
+## Implemented by
+
+* [HttpResponseImpl](../classes/httpresponseimpl.md)
+
+## Index
+
+### Properties
+
+* [addHeader](httpresponse.md#addheader)
+* [body](httpresponse.md#body)
+* [headers](httpresponse.md#headers)
+* [removeHeader](httpresponse.md#removeheader)
+* [replaceHeader](httpresponse.md#replaceheader)
+* [setBody](httpresponse.md#setbody)
+* [setHeaders](httpresponse.md#setheaders)
+* [setStatus](httpresponse.md#setstatus)
+* [status](httpresponse.md#status)
+
+## Properties
+
+###  addHeader
+
+• **addHeader**: *function*
+
+Defined in src/core/http.ts:71
+
+#### Type declaration:
+
+▸ (`header`: keyof ResponseHttpHeaders, `value`: string | string[]): *[HttpResponse](httpresponse.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof ResponseHttpHeaders |
+`value` | string &#124; string[] |
+
+___
+
+###  body
+
+• **body**: *[HttpBody](httpbody.md)*
+
+*Inherited from [HttpMessage](httpmessage.md).[body](httpmessage.md#body)*
+
+Defined in src/core/http.ts:35
+
+___
+
+###  headers
+
+• **headers**: *[ResponseHttpHeaders](responsehttpheaders.md)*
+
+*Overrides [HttpMessage](httpmessage.md).[headers](httpmessage.md#headers)*
+
+Defined in src/core/http.ts:67
+
+___
+
+###  removeHeader
+
+• **removeHeader**: *function*
+
+Defined in src/core/http.ts:79
+
+#### Type declaration:
+
+▸ (`header`: keyof ResponseHttpHeaders): *[HttpResponse](httpresponse.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof ResponseHttpHeaders |
+
+___
+
+###  replaceHeader
+
+• **replaceHeader**: *function*
+
+Defined in src/core/http.ts:75
+
+#### Type declaration:
+
+▸ (`header`: keyof ResponseHttpHeaders, `value`: string | string[]): *[HttpResponse](httpresponse.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof ResponseHttpHeaders |
+`value` | string &#124; string[] |
+
+___
+
+###  setBody
+
+• **setBody**: *function*
+
+Defined in src/core/http.ts:81
+
+#### Type declaration:
+
+▸ (`body`: [HttpBody](httpbody.md)): *[HttpResponse](httpresponse.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`body` | [HttpBody](httpbody.md) |
+
+___
+
+###  setHeaders
+
+• **setHeaders**: *function*
+
+Defined in src/core/http.ts:70
+
+#### Type declaration:
+
+▸ (`headers`: [ResponseHttpHeaders](responsehttpheaders.md)): *[HttpResponse](httpresponse.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`headers` | [ResponseHttpHeaders](responsehttpheaders.md) |
+
+___
+
+###  setStatus
+
+• **setStatus**: *function*
+
+Defined in src/core/http.ts:83
+
+#### Type declaration:
+
+▸ (`status`: [HttpStatus](../enums/httpstatus.md)): *[HttpResponse](httpresponse.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`status` | [HttpStatus](../enums/httpstatus.md) |
+
+___
+
+###  status
+
+• **status**: *[HttpStatus](../enums/httpstatus.md)*
+
+Defined in src/core/http.ts:68

--- a/website/docs/api/interfaces/key.md
+++ b/website/docs/api/interfaces/key.md
@@ -1,0 +1,63 @@
+---
+id: "key"
+title: "Key"
+sidebar_label: "Key"
+---
+
+[http4ts - v0.0.3](../index.md) › [Key](key.md)
+
+Metadata about a key.
+
+## Hierarchy
+
+* **Key**
+
+## Index
+
+### Properties
+
+* [modifier](key.md#modifier)
+* [name](key.md#name)
+* [pattern](key.md#pattern)
+* [prefix](key.md#prefix)
+* [suffix](key.md#suffix)
+
+## Properties
+
+###  modifier
+
+• **modifier**: *string*
+
+Defined in src/core/routing/path-to-regexp.ts:444
+
+___
+
+###  name
+
+• **name**: *string | number*
+
+Defined in src/core/routing/path-to-regexp.ts:440
+
+___
+
+###  pattern
+
+• **pattern**: *string*
+
+Defined in src/core/routing/path-to-regexp.ts:443
+
+___
+
+###  prefix
+
+• **prefix**: *string*
+
+Defined in src/core/routing/path-to-regexp.ts:441
+
+___
+
+###  suffix
+
+• **suffix**: *string*
+
+Defined in src/core/routing/path-to-regexp.ts:442

--- a/website/docs/api/interfaces/lextoken.md
+++ b/website/docs/api/interfaces/lextoken.md
@@ -1,0 +1,45 @@
+---
+id: "lextoken"
+title: "LexToken"
+sidebar_label: "LexToken"
+---
+
+[http4ts - v0.0.3](../index.md) › [LexToken](lextoken.md)
+
+Tokenizer results.
+
+## Hierarchy
+
+* **LexToken**
+
+## Index
+
+### Properties
+
+* [index](lextoken.md#index)
+* [type](lextoken.md#type)
+* [value](lextoken.md#value)
+
+## Properties
+
+###  index
+
+• **index**: *number*
+
+Defined in src/core/routing/path-to-regexp.ts:16
+
+___
+
+###  type
+
+• **type**: *"OPEN" | "CLOSE" | "PATTERN" | "NAME" | "CHAR" | "ESCAPED_CHAR" | "MODIFIER" | "END"*
+
+Defined in src/core/routing/path-to-regexp.ts:7
+
+___
+
+###  value
+
+• **value**: *string*
+
+Defined in src/core/routing/path-to-regexp.ts:17

--- a/website/docs/api/interfaces/matchresult.md
+++ b/website/docs/api/interfaces/matchresult.md
@@ -1,0 +1,49 @@
+---
+id: "matchresult"
+title: "MatchResult"
+sidebar_label: "MatchResult"
+---
+
+[http4ts - v0.0.3](../index.md) › [MatchResult](matchresult.md)
+
+A match result contains data about the path match.
+
+## Type parameters
+
+▪ **P**: *object*
+
+## Hierarchy
+
+* **MatchResult**
+
+## Index
+
+### Properties
+
+* [index](matchresult.md#index)
+* [params](matchresult.md#params)
+* [path](matchresult.md#path)
+
+## Properties
+
+###  index
+
+• **index**: *number*
+
+Defined in src/core/routing/path-to-regexp.ts:358
+
+___
+
+###  params
+
+• **params**: *P*
+
+Defined in src/core/routing/path-to-regexp.ts:359
+
+___
+
+###  path
+
+• **path**: *string*
+
+Defined in src/core/routing/path-to-regexp.ts:357

--- a/website/docs/api/interfaces/parseoptions.md
+++ b/website/docs/api/interfaces/parseoptions.md
@@ -1,0 +1,38 @@
+---
+id: "parseoptions"
+title: "ParseOptions"
+sidebar_label: "ParseOptions"
+---
+
+[http4ts - v0.0.3](../index.md) › [ParseOptions](parseoptions.md)
+
+## Hierarchy
+
+* **ParseOptions**
+
+## Index
+
+### Properties
+
+* [delimiter](parseoptions.md#optional-delimiter)
+* [prefixes](parseoptions.md#optional-prefixes)
+
+## Properties
+
+### `Optional` delimiter
+
+• **delimiter**? : *undefined | string*
+
+Defined in src/core/routing/path-to-regexp.ts:132
+
+Set the default delimiter for repeat parameters. (default: `'/'`)
+
+___
+
+### `Optional` prefixes
+
+• **prefixes**? : *undefined | string*
+
+Defined in src/core/routing/path-to-regexp.ts:136
+
+List of characters to automatically consider prefixes when parsing.

--- a/website/docs/api/interfaces/regexptofunctionoptions.md
+++ b/website/docs/api/interfaces/regexptofunctionoptions.md
@@ -1,0 +1,27 @@
+---
+id: "regexptofunctionoptions"
+title: "RegexpToFunctionOptions"
+sidebar_label: "RegexpToFunctionOptions"
+---
+
+[http4ts - v0.0.3](../index.md) › [RegexpToFunctionOptions](regexptofunctionoptions.md)
+
+## Hierarchy
+
+* **RegexpToFunctionOptions**
+
+## Index
+
+### Properties
+
+* [decode](regexptofunctionoptions.md#optional-decode)
+
+## Properties
+
+### `Optional` decode
+
+• **decode**? : *undefined | function*
+
+Defined in src/core/routing/path-to-regexp.ts:350
+
+Function for decoding strings for params.

--- a/website/docs/api/interfaces/requesthttpheaders.md
+++ b/website/docs/api/interfaces/requesthttpheaders.md
@@ -1,0 +1,382 @@
+---
+id: "requesthttpheaders"
+title: "RequestHttpHeaders"
+sidebar_label: "RequestHttpHeaders"
+---
+
+[http4ts - v0.0.3](../index.md) › [RequestHttpHeaders](requesthttpheaders.md)
+
+## Hierarchy
+
+* [HttpHeaders](httpheaders.md)
+
+  ↳ **RequestHttpHeaders**
+
+## Indexable
+
+* \[ **header**: *string*\]: string | string[] | undefined
+
+## Index
+
+### Properties
+
+* [a-im](requesthttpheaders.md#optional-a-im)
+* [accept](requesthttpheaders.md#optional-accept)
+* [accept-charset](requesthttpheaders.md#optional-accept-charset)
+* [accept-datetime](requesthttpheaders.md#optional-accept-datetime)
+* [accept-encoding](requesthttpheaders.md#optional-accept-encoding)
+* [accept-language](requesthttpheaders.md#optional-accept-language)
+* [access-control-request-headers](requesthttpheaders.md#optional-access-control-request-headers)
+* [access-control-request-method](requesthttpheaders.md#optional-access-control-request-method)
+* [authorization](requesthttpheaders.md#optional-authorization)
+* [cache-control](requesthttpheaders.md#optional-cache-control)
+* [connection](requesthttpheaders.md#optional-connection)
+* [content-length](requesthttpheaders.md#optional-content-length)
+* [content-md5](requesthttpheaders.md#optional-content-md5)
+* [content-type](requesthttpheaders.md#optional-content-type)
+* [cookie](requesthttpheaders.md#optional-cookie)
+* [date](requesthttpheaders.md#optional-date)
+* [expect](requesthttpheaders.md#optional-expect)
+* [forwarded](requesthttpheaders.md#optional-forwarded)
+* [from](requesthttpheaders.md#optional-from)
+* [host](requesthttpheaders.md#optional-host)
+* [http2-settings](requesthttpheaders.md#optional-http2-settings)
+* [if-match](requesthttpheaders.md#optional-if-match)
+* [if-modified-since](requesthttpheaders.md#optional-if-modified-since)
+* [if-none-match](requesthttpheaders.md#optional-if-none-match)
+* [if-range](requesthttpheaders.md#optional-if-range)
+* [if-unmodified-since](requesthttpheaders.md#optional-if-unmodified-since)
+* [max-forwards](requesthttpheaders.md#optional-max-forwards)
+* [origin](requesthttpheaders.md#optional-origin)
+* [permanent](requesthttpheaders.md#optional-permanent)
+* [pragma](requesthttpheaders.md#optional-pragma)
+* [proxy-authorization](requesthttpheaders.md#optional-proxy-authorization)
+* [range](requesthttpheaders.md#optional-range)
+* [referer](requesthttpheaders.md#optional-referer)
+* [te](requesthttpheaders.md#optional-te)
+* [trailer](requesthttpheaders.md#optional-trailer)
+* [transfer-encoding](requesthttpheaders.md#optional-transfer-encoding)
+* [upgrade](requesthttpheaders.md#optional-upgrade)
+* [user-agent](requesthttpheaders.md#optional-user-agent)
+* [via](requesthttpheaders.md#optional-via)
+* [warning](requesthttpheaders.md#optional-warning)
+
+## Properties
+
+### `Optional` a-im
+
+• **a-im**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:6
+
+___
+
+### `Optional` accept
+
+• **accept**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:7
+
+___
+
+### `Optional` accept-charset
+
+• **accept-charset**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:8
+
+___
+
+### `Optional` accept-datetime
+
+• **accept-datetime**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:9
+
+___
+
+### `Optional` accept-encoding
+
+• **accept-encoding**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:10
+
+___
+
+### `Optional` accept-language
+
+• **accept-language**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:11
+
+___
+
+### `Optional` access-control-request-headers
+
+• **access-control-request-headers**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:13
+
+___
+
+### `Optional` access-control-request-method
+
+• **access-control-request-method**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:12
+
+___
+
+### `Optional` authorization
+
+• **authorization**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:14
+
+___
+
+### `Optional` cache-control
+
+• **cache-control**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:15
+
+___
+
+### `Optional` connection
+
+• **connection**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:16
+
+___
+
+### `Optional` content-length
+
+• **content-length**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:18
+
+___
+
+### `Optional` content-md5
+
+• **content-md5**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:19
+
+___
+
+### `Optional` content-type
+
+• **content-type**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:20
+
+___
+
+### `Optional` cookie
+
+• **cookie**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:21
+
+___
+
+### `Optional` date
+
+• **date**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:22
+
+___
+
+### `Optional` expect
+
+• **expect**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:23
+
+___
+
+### `Optional` forwarded
+
+• **forwarded**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:24
+
+___
+
+### `Optional` from
+
+• **from**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:25
+
+___
+
+### `Optional` host
+
+• **host**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:26
+
+___
+
+### `Optional` http2-settings
+
+• **http2-settings**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:27
+
+___
+
+### `Optional` if-match
+
+• **if-match**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:28
+
+___
+
+### `Optional` if-modified-since
+
+• **if-modified-since**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:29
+
+___
+
+### `Optional` if-none-match
+
+• **if-none-match**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:30
+
+___
+
+### `Optional` if-range
+
+• **if-range**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:31
+
+___
+
+### `Optional` if-unmodified-since
+
+• **if-unmodified-since**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:32
+
+___
+
+### `Optional` max-forwards
+
+• **max-forwards**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:33
+
+___
+
+### `Optional` origin
+
+• **origin**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:34
+
+___
+
+### `Optional` permanent
+
+• **permanent**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:17
+
+___
+
+### `Optional` pragma
+
+• **pragma**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:35
+
+___
+
+### `Optional` proxy-authorization
+
+• **proxy-authorization**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:36
+
+___
+
+### `Optional` range
+
+• **range**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:37
+
+___
+
+### `Optional` referer
+
+• **referer**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:38
+
+___
+
+### `Optional` te
+
+• **te**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:39
+
+___
+
+### `Optional` trailer
+
+• **trailer**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:40
+
+___
+
+### `Optional` transfer-encoding
+
+• **transfer-encoding**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:41
+
+___
+
+### `Optional` upgrade
+
+• **upgrade**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:43
+
+___
+
+### `Optional` user-agent
+
+• **user-agent**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:42
+
+___
+
+### `Optional` via
+
+• **via**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:44
+
+___
+
+### `Optional` warning
+
+• **warning**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:45

--- a/website/docs/api/interfaces/responsehttpheaders.md
+++ b/website/docs/api/interfaces/responsehttpheaders.md
@@ -1,0 +1,508 @@
+---
+id: "responsehttpheaders"
+title: "ResponseHttpHeaders"
+sidebar_label: "ResponseHttpHeaders"
+---
+
+[http4ts - v0.0.3](../index.md) › [ResponseHttpHeaders](responsehttpheaders.md)
+
+## Hierarchy
+
+* [HttpHeaders](httpheaders.md)
+
+  ↳ **ResponseHttpHeaders**
+
+## Indexable
+
+* \[ **header**: *string*\]: string | string[] | undefined
+
+## Index
+
+### Properties
+
+* [accept](responsehttpheaders.md#optional-accept)
+* [accept-language](responsehttpheaders.md#optional-accept-language)
+* [accept-patch](responsehttpheaders.md#optional-accept-patch)
+* [accept-ranges](responsehttpheaders.md#optional-accept-ranges)
+* [access-control-allow-credentials](responsehttpheaders.md#optional-access-control-allow-credentials)
+* [access-control-allow-headers](responsehttpheaders.md#optional-access-control-allow-headers)
+* [access-control-allow-methods](responsehttpheaders.md#optional-access-control-allow-methods)
+* [access-control-allow-origin](responsehttpheaders.md#optional-access-control-allow-origin)
+* [access-control-expose-headers](responsehttpheaders.md#optional-access-control-expose-headers)
+* [access-control-max-age](responsehttpheaders.md#optional-access-control-max-age)
+* [age](responsehttpheaders.md#optional-age)
+* [allow](responsehttpheaders.md#optional-allow)
+* [alt-svc](responsehttpheaders.md#optional-alt-svc)
+* [authorization](responsehttpheaders.md#optional-authorization)
+* [cache-control](responsehttpheaders.md#optional-cache-control)
+* [connection](responsehttpheaders.md#optional-connection)
+* [content-disposition](responsehttpheaders.md#optional-content-disposition)
+* [content-encoding](responsehttpheaders.md#optional-content-encoding)
+* [content-language](responsehttpheaders.md#optional-content-language)
+* [content-length](responsehttpheaders.md#optional-content-length)
+* [content-location](responsehttpheaders.md#optional-content-location)
+* [content-range](responsehttpheaders.md#optional-content-range)
+* [content-type](responsehttpheaders.md#optional-content-type)
+* [cookie](responsehttpheaders.md#optional-cookie)
+* [date](responsehttpheaders.md#optional-date)
+* [expect](responsehttpheaders.md#optional-expect)
+* [expires](responsehttpheaders.md#optional-expires)
+* [forwarded](responsehttpheaders.md#optional-forwarded)
+* [from](responsehttpheaders.md#optional-from)
+* [host](responsehttpheaders.md#optional-host)
+* [if-match](responsehttpheaders.md#optional-if-match)
+* [if-modified-since](responsehttpheaders.md#optional-if-modified-since)
+* [if-none-match](responsehttpheaders.md#optional-if-none-match)
+* [if-unmodified-since](responsehttpheaders.md#optional-if-unmodified-since)
+* [last-modified](responsehttpheaders.md#optional-last-modified)
+* [location](responsehttpheaders.md#optional-location)
+* [pragma](responsehttpheaders.md#optional-pragma)
+* [proxy-authenticate](responsehttpheaders.md#optional-proxy-authenticate)
+* [proxy-authorization](responsehttpheaders.md#optional-proxy-authorization)
+* [public-key-pins](responsehttpheaders.md#optional-public-key-pins)
+* [range](responsehttpheaders.md#optional-range)
+* [referer](responsehttpheaders.md#optional-referer)
+* [retry-after](responsehttpheaders.md#optional-retry-after)
+* [set-cookie](responsehttpheaders.md#optional-set-cookie)
+* [strict-transport-security](responsehttpheaders.md#optional-strict-transport-security)
+* [tk](responsehttpheaders.md#optional-tk)
+* [trailer](responsehttpheaders.md#optional-trailer)
+* [transfer-encoding](responsehttpheaders.md#optional-transfer-encoding)
+* [upgrade](responsehttpheaders.md#optional-upgrade)
+* [user-agent](responsehttpheaders.md#optional-user-agent)
+* [vary](responsehttpheaders.md#optional-vary)
+* [via](responsehttpheaders.md#optional-via)
+* [warning](responsehttpheaders.md#optional-warning)
+* [www-authenticate](responsehttpheaders.md#optional-www-authenticate)
+
+## Properties
+
+### `Optional` accept
+
+• **accept**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:49
+
+___
+
+### `Optional` accept-language
+
+• **accept-language**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:50
+
+___
+
+### `Optional` accept-patch
+
+• **accept-patch**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:51
+
+___
+
+### `Optional` accept-ranges
+
+• **accept-ranges**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:52
+
+___
+
+### `Optional` access-control-allow-credentials
+
+• **access-control-allow-credentials**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:53
+
+___
+
+### `Optional` access-control-allow-headers
+
+• **access-control-allow-headers**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:54
+
+___
+
+### `Optional` access-control-allow-methods
+
+• **access-control-allow-methods**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:55
+
+___
+
+### `Optional` access-control-allow-origin
+
+• **access-control-allow-origin**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:56
+
+___
+
+### `Optional` access-control-expose-headers
+
+• **access-control-expose-headers**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:57
+
+___
+
+### `Optional` access-control-max-age
+
+• **access-control-max-age**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:58
+
+___
+
+### `Optional` age
+
+• **age**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:59
+
+___
+
+### `Optional` allow
+
+• **allow**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:60
+
+___
+
+### `Optional` alt-svc
+
+• **alt-svc**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:61
+
+___
+
+### `Optional` authorization
+
+• **authorization**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:62
+
+___
+
+### `Optional` cache-control
+
+• **cache-control**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:63
+
+___
+
+### `Optional` connection
+
+• **connection**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:64
+
+___
+
+### `Optional` content-disposition
+
+• **content-disposition**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:65
+
+___
+
+### `Optional` content-encoding
+
+• **content-encoding**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:66
+
+___
+
+### `Optional` content-language
+
+• **content-language**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:67
+
+___
+
+### `Optional` content-length
+
+• **content-length**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:68
+
+___
+
+### `Optional` content-location
+
+• **content-location**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:69
+
+___
+
+### `Optional` content-range
+
+• **content-range**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:70
+
+___
+
+### `Optional` content-type
+
+• **content-type**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:71
+
+___
+
+### `Optional` cookie
+
+• **cookie**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:72
+
+___
+
+### `Optional` date
+
+• **date**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:73
+
+___
+
+### `Optional` expect
+
+• **expect**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:74
+
+___
+
+### `Optional` expires
+
+• **expires**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:75
+
+___
+
+### `Optional` forwarded
+
+• **forwarded**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:76
+
+___
+
+### `Optional` from
+
+• **from**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:77
+
+___
+
+### `Optional` host
+
+• **host**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:78
+
+___
+
+### `Optional` if-match
+
+• **if-match**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:79
+
+___
+
+### `Optional` if-modified-since
+
+• **if-modified-since**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:80
+
+___
+
+### `Optional` if-none-match
+
+• **if-none-match**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:81
+
+___
+
+### `Optional` if-unmodified-since
+
+• **if-unmodified-since**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:82
+
+___
+
+### `Optional` last-modified
+
+• **last-modified**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:83
+
+___
+
+### `Optional` location
+
+• **location**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:84
+
+___
+
+### `Optional` pragma
+
+• **pragma**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:85
+
+___
+
+### `Optional` proxy-authenticate
+
+• **proxy-authenticate**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:86
+
+___
+
+### `Optional` proxy-authorization
+
+• **proxy-authorization**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:87
+
+___
+
+### `Optional` public-key-pins
+
+• **public-key-pins**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:88
+
+___
+
+### `Optional` range
+
+• **range**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:89
+
+___
+
+### `Optional` referer
+
+• **referer**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:90
+
+___
+
+### `Optional` retry-after
+
+• **retry-after**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:91
+
+___
+
+### `Optional` set-cookie
+
+• **set-cookie**? : *string[]*
+
+Defined in src/core/http-headers.ts:92
+
+___
+
+### `Optional` strict-transport-security
+
+• **strict-transport-security**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:93
+
+___
+
+### `Optional` tk
+
+• **tk**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:94
+
+___
+
+### `Optional` trailer
+
+• **trailer**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:95
+
+___
+
+### `Optional` transfer-encoding
+
+• **transfer-encoding**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:96
+
+___
+
+### `Optional` upgrade
+
+• **upgrade**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:97
+
+___
+
+### `Optional` user-agent
+
+• **user-agent**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:98
+
+___
+
+### `Optional` vary
+
+• **vary**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:99
+
+___
+
+### `Optional` via
+
+• **via**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:100
+
+___
+
+### `Optional` warning
+
+• **warning**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:101
+
+___
+
+### `Optional` www-authenticate
+
+• **www-authenticate**? : *undefined | string*
+
+Defined in src/core/http-headers.ts:102

--- a/website/docs/api/interfaces/routedefinition.md
+++ b/website/docs/api/interfaces/routedefinition.md
@@ -1,0 +1,52 @@
+---
+id: "routedefinition"
+title: "RouteDefinition"
+sidebar_label: "RouteDefinition"
+---
+
+[http4ts - v0.0.3](../index.md) › [RouteDefinition](routedefinition.md)
+
+## Hierarchy
+
+* **RouteDefinition**
+
+## Index
+
+### Properties
+
+* [handler](routedefinition.md#handler)
+* [keys](routedefinition.md#optional-keys)
+* [method](routedefinition.md#optional-method)
+* [uriTemplate](routedefinition.md#optional-uritemplate)
+
+## Properties
+
+###  handler
+
+• **handler**: *[RoutedHttpHandler](../index.md#routedhttphandler)*
+
+Defined in src/core/routing/routes.ts:21
+
+___
+
+### `Optional` keys
+
+• **keys**? : *[Key](key.md)[]*
+
+Defined in src/core/routing/routes.ts:20
+
+___
+
+### `Optional` method
+
+• **method**? : *[HttpMethod](../index.md#httpmethod)*
+
+Defined in src/core/routing/routes.ts:18
+
+___
+
+### `Optional` uriTemplate
+
+• **uriTemplate**? : *RegExp*
+
+Defined in src/core/routing/routes.ts:19

--- a/website/docs/api/interfaces/routedhttprequest.md
+++ b/website/docs/api/interfaces/routedhttprequest.md
@@ -1,0 +1,323 @@
+---
+id: "routedhttprequest"
+title: "RoutedHttpRequest"
+sidebar_label: "RoutedHttpRequest"
+---
+
+[http4ts - v0.0.3](../index.md) › [RoutedHttpRequest](routedhttprequest.md)
+
+## Hierarchy
+
+  ↳ [HttpRequest](httprequest.md)
+
+  ↳ **RoutedHttpRequest**
+
+## Index
+
+### Properties
+
+* [addHeader](routedhttprequest.md#addheader)
+* [addQuery](routedhttprequest.md#addquery)
+* [body](routedhttprequest.md#body)
+* [headers](routedhttprequest.md#headers)
+* [method](routedhttprequest.md#method)
+* [path](routedhttprequest.md#path)
+* [query](routedhttprequest.md#query)
+* [removeHeader](routedhttprequest.md#removeheader)
+* [removeQuery](routedhttprequest.md#removequery)
+* [replaceHeader](routedhttprequest.md#replaceheader)
+* [replaceQuery](routedhttprequest.md#replacequery)
+* [routeParams](routedhttprequest.md#routeparams)
+* [setBody](routedhttprequest.md#setbody)
+* [setHeaders](routedhttprequest.md#setheaders)
+* [setMethod](routedhttprequest.md#setmethod)
+* [setUrl](routedhttprequest.md#seturl)
+* [url](routedhttprequest.md#url)
+
+## Properties
+
+###  addHeader
+
+• **addHeader**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[addHeader](httprequest.md#addheader)*
+
+Defined in src/core/http.ts:44
+
+#### Type declaration:
+
+▸ (`header`: keyof RequestHttpHeaders, `value`: string | string[]): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof RequestHttpHeaders |
+`value` | string &#124; string[] |
+
+___
+
+###  addQuery
+
+• **addQuery**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[addQuery](httprequest.md#addquery)*
+
+Defined in src/core/http.ts:57
+
+#### Type declaration:
+
+▸ (`name`: string, `value`: string | string[]): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | string &#124; string[] |
+
+___
+
+###  body
+
+• **body**: *[HttpBody](httpbody.md)*
+
+*Inherited from [HttpMessage](httpmessage.md).[body](httpmessage.md#body)*
+
+Defined in src/core/http.ts:35
+
+___
+
+###  headers
+
+• **headers**: *[RequestHttpHeaders](requesthttpheaders.md)*
+
+*Inherited from [HttpRequest](httprequest.md).[headers](httprequest.md#headers)*
+
+*Overrides [HttpMessage](httpmessage.md).[headers](httpmessage.md#headers)*
+
+Defined in src/core/http.ts:39
+
+___
+
+###  method
+
+• **method**: *[HttpMethod](../index.md#httpmethod)*
+
+*Inherited from [HttpRequest](httprequest.md).[method](httprequest.md#method)*
+
+Defined in src/core/http.ts:40
+
+___
+
+###  path
+
+• **path**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[path](httprequest.md#path)*
+
+Defined in src/core/http.ts:59
+
+#### Type declaration:
+
+▸ (): *string*
+
+___
+
+###  query
+
+• **query**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[query](httprequest.md#query)*
+
+Defined in src/core/http.ts:55
+
+#### Type declaration:
+
+▸ (`name`: string): *[HttpQuery](../index.md#httpquery)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+___
+
+###  removeHeader
+
+• **removeHeader**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[removeHeader](httprequest.md#removeheader)*
+
+Defined in src/core/http.ts:52
+
+#### Type declaration:
+
+▸ (`header`: keyof RequestHttpHeaders): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof RequestHttpHeaders |
+
+___
+
+###  removeQuery
+
+• **removeQuery**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[removeQuery](httprequest.md#removequery)*
+
+Defined in src/core/http.ts:56
+
+#### Type declaration:
+
+▸ (`name`: string): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+___
+
+###  replaceHeader
+
+• **replaceHeader**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[replaceHeader](httprequest.md#replaceheader)*
+
+Defined in src/core/http.ts:48
+
+#### Type declaration:
+
+▸ (`header`: keyof RequestHttpHeaders, `value`: string | string[]): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`header` | keyof RequestHttpHeaders |
+`value` | string &#124; string[] |
+
+___
+
+###  replaceQuery
+
+• **replaceQuery**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[replaceQuery](httprequest.md#replacequery)*
+
+Defined in src/core/http.ts:58
+
+#### Type declaration:
+
+▸ (`name`: string, `value`: string | string[]): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | string &#124; string[] |
+
+___
+
+###  routeParams
+
+• **routeParams**: *Record‹string, string›*
+
+Defined in src/core/routing/routes.ts:8
+
+___
+
+###  setBody
+
+• **setBody**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[setBody](httprequest.md#setbody)*
+
+Defined in src/core/http.ts:61
+
+#### Type declaration:
+
+▸ (`body`: [HttpBody](httpbody.md) | string): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`body` | [HttpBody](httpbody.md) &#124; string |
+
+___
+
+###  setHeaders
+
+• **setHeaders**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[setHeaders](httprequest.md#setheaders)*
+
+Defined in src/core/http.ts:43
+
+#### Type declaration:
+
+▸ (`headers`: [RequestHttpHeaders](requesthttpheaders.md)): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`headers` | [RequestHttpHeaders](requesthttpheaders.md) |
+
+___
+
+###  setMethod
+
+• **setMethod**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[setMethod](httprequest.md#setmethod)*
+
+Defined in src/core/http.ts:63
+
+#### Type declaration:
+
+▸ (`method`: [HttpMethod](../index.md#httpmethod)): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`method` | [HttpMethod](../index.md#httpmethod) |
+
+___
+
+###  setUrl
+
+• **setUrl**: *function*
+
+*Inherited from [HttpRequest](httprequest.md).[setUrl](httprequest.md#seturl)*
+
+Defined in src/core/http.ts:54
+
+#### Type declaration:
+
+▸ (`url`: string): *[HttpRequest](httprequest.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`url` | string |
+
+___
+
+###  url
+
+• **url**: *string*
+
+*Inherited from [HttpRequest](httprequest.md).[url](httprequest.md#url)*
+
+Defined in src/core/http.ts:41

--- a/website/docs/api/interfaces/tokenstofunctionoptions.md
+++ b/website/docs/api/interfaces/tokenstofunctionoptions.md
@@ -1,0 +1,49 @@
+---
+id: "tokenstofunctionoptions"
+title: "TokensToFunctionOptions"
+sidebar_label: "TokensToFunctionOptions"
+---
+
+[http4ts - v0.0.3](../index.md) › [TokensToFunctionOptions](tokenstofunctionoptions.md)
+
+## Hierarchy
+
+* **TokensToFunctionOptions**
+
+## Index
+
+### Properties
+
+* [encode](tokenstofunctionoptions.md#optional-encode)
+* [sensitive](tokenstofunctionoptions.md#optional-sensitive)
+* [validate](tokenstofunctionoptions.md#optional-validate)
+
+## Properties
+
+### `Optional` encode
+
+• **encode**? : *undefined | function*
+
+Defined in src/core/routing/path-to-regexp.ts:244
+
+Function for encoding input strings for output.
+
+___
+
+### `Optional` sensitive
+
+• **sensitive**? : *undefined | false | true*
+
+Defined in src/core/routing/path-to-regexp.ts:240
+
+When `true` the regexp will be case sensitive. (default: `false`)
+
+___
+
+### `Optional` validate
+
+• **validate**? : *undefined | false | true*
+
+Defined in src/core/routing/path-to-regexp.ts:248
+
+When `false` the function can produce an invalid (unmatched) path. (default: `true`)

--- a/website/docs/api/interfaces/tokenstoregexpoptions.md
+++ b/website/docs/api/interfaces/tokenstoregexpoptions.md
@@ -1,0 +1,93 @@
+---
+id: "tokenstoregexpoptions"
+title: "TokensToRegexpOptions"
+sidebar_label: "TokensToRegexpOptions"
+---
+
+[http4ts - v0.0.3](../index.md) › [TokensToRegexpOptions](tokenstoregexpoptions.md)
+
+## Hierarchy
+
+* **TokensToRegexpOptions**
+
+## Index
+
+### Properties
+
+* [delimiter](tokenstoregexpoptions.md#optional-delimiter)
+* [encode](tokenstoregexpoptions.md#optional-encode)
+* [end](tokenstoregexpoptions.md#optional-end)
+* [endsWith](tokenstoregexpoptions.md#optional-endswith)
+* [sensitive](tokenstoregexpoptions.md#optional-sensitive)
+* [start](tokenstoregexpoptions.md#optional-start)
+* [strict](tokenstoregexpoptions.md#optional-strict)
+
+## Properties
+
+### `Optional` delimiter
+
+• **delimiter**? : *undefined | string*
+
+Defined in src/core/routing/path-to-regexp.ts:519
+
+Sets the final character for non-ending optimistic matches. (default: `/`)
+
+___
+
+### `Optional` encode
+
+• **encode**? : *undefined | function*
+
+Defined in src/core/routing/path-to-regexp.ts:527
+
+Encode path tokens for use in the `RegExp`.
+
+___
+
+### `Optional` end
+
+• **end**? : *undefined | false | true*
+
+Defined in src/core/routing/path-to-regexp.ts:511
+
+When `true` the regexp will match to the end of the string. (default: `true`)
+
+___
+
+### `Optional` endsWith
+
+• **endsWith**? : *undefined | string*
+
+Defined in src/core/routing/path-to-regexp.ts:523
+
+List of characters that can also be "end" characters.
+
+___
+
+### `Optional` sensitive
+
+• **sensitive**? : *undefined | false | true*
+
+Defined in src/core/routing/path-to-regexp.ts:503
+
+When `true` the regexp will be case sensitive. (default: `false`)
+
+___
+
+### `Optional` start
+
+• **start**? : *undefined | false | true*
+
+Defined in src/core/routing/path-to-regexp.ts:515
+
+When `true` the regexp will match from the beginning of the string. (default: `true`)
+
+___
+
+### `Optional` strict
+
+• **strict**? : *undefined | false | true*
+
+Defined in src/core/routing/path-to-regexp.ts:507
+
+When `true` the regexp allows an optional trailing delimiter to match. (default: `false`)

--- a/website/docs/api/interfaces/uri.md
+++ b/website/docs/api/interfaces/uri.md
@@ -1,0 +1,34 @@
+---
+id: "uri"
+title: "URI"
+sidebar_label: "URI"
+---
+
+[http4ts - v0.0.3](../index.md) › [URI](uri.md)
+
+## Hierarchy
+
+* **URI**
+
+## Index
+
+### Properties
+
+* [path](uri.md#path)
+* [queryString](uri.md#querystring)
+
+## Properties
+
+###  path
+
+• **path**: *string*
+
+Defined in src/core/http-request/http-request-impl.ts:7
+
+___
+
+###  queryString
+
+• **queryString**: *URLSearchParams*
+
+Defined in src/core/http-request/http-request-impl.ts:6

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -18,6 +18,7 @@ module.exports = {
       "guides/unit-tests"
     ],
     "API Reference": [
+      "api/index",
       "reference/http",
       "reference/body",
       "reference/router",


### PR DESCRIPTION
* Uses docusaurus2 theme
* Linked in sidebar as a single page, currently titled "Globals"
* Individual members are *not* in the sidebar
* Adds `typedoc` npm script
  * Cleans the dir first
  * Runs typedoc using options configured in tsconfig.json
    * Relies on the `typedoc-plugin-markdown` plugin for docusaurus2 support
  * Removes the sidebar file that is incorrectly produced
    * The `skipSidebar` arg is not yet supported in `docusaurus2` (see https://github.com/tom-grey/typedoc-plugin-markdown/pull/124)